### PR TITLE
wire up docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
     needs:
       - nix
       - conda
+      - docker-image-build
     runs-on: ubuntu-latest
     concurrency: release
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,11 +3,11 @@ name: "CodeQL"
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
-      - master
+      - main
   schedule:
     - cron: "24 22 * * 1"
 


### PR DESCRIPTION
- ci: run codeql against the correct branch name
- ci: wire up the docker image in CI
