### PR TITLE
feat: support buf for FileDescriptorSet generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build package and run tests
         run: nix build --print-build-logs --keep-going '.#protoletariat${{ matrix.python-version }}'
-  docker-image-build:
+  docker-image:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -120,7 +120,7 @@ jobs:
     needs:
       - nix
       - conda
-      - docker-image-build
+      - docker-image
     runs-on: ubuntu-latest
     concurrency: release
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           extraPullNames: nix-community,poetry2nix
 
-      - name: Build package and run tests
+      - name: Build docker image
         run: nix build --print-build-logs --keep-going '.#protoletariat-image'
   conda:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup buf
+        uses: bufbuild/buf-setup-action@v0.7.0
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,28 @@ on:
 name: CI
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable-small
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: protoletariat
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extraPullNames: nix-community,poetry2nix
+
+      - name: Run pre-commit checks
+        run: nix develop -c pre-commit run --all-files
   nix:
     strategy:
       fail-fast: false
@@ -121,6 +143,7 @@ jobs:
       - nix
       - conda
       - docker-image
+      - pre-commit
     runs-on: ubuntu-latest
     concurrency: release
     steps:

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 .mypy_cache
 .pre-commit-config.yaml
 CHANGELOG.md
+.pytest_cache

--- a/README.md
+++ b/README.md
@@ -58,16 +58,16 @@ The `out/thing1_pb2.py` file should show a diff containing at least these lines:
 
 ## How it works
 
-At a high level, `protoletariat` converts absolute imports to relative imports.
+At a high level `protoletariat` converts absolute imports to relative imports.
 
-However, it doesn't just convert any absolute import to a relative import.
+However, it doesn't convert just any absolute import to a relative import.
 
 The `protol` tool will only convert imports that were generated from `.proto` files. It
 does this by inspecting `FileDescriptorProtos` from the protobuf files.
 
-The core mechanism is implemented using a simplified form of pattern matching,
-that looks at the Python AST, and if an import pattern is matched and
-corresponding rewrite rule is fired.
+The core rewrite mechanism is implemented using a simplified form of pattern
+matching, that looks at the Python AST, and if an import pattern is matched a
+corresponding rewrite rule is invoked.
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ protoc --python_out=out --proto_path=directory/containing/protos thing1.proto 
 3. Run `protol` on the generated code
 
 ```sh
-$ protol --create-init --overwrite -g out --proto-path=directory/containing/protos thing1.proto thing2.proto
+$ protol --create-init --overwrite -g out protoc --proto-path=directory/containing/protos thing1.proto thing2.proto
 ```
 
 The `out/thing1_pb2.py` file should show a diff containing at least these lines:
@@ -72,21 +72,23 @@ corresponding rewrite rule is fired.
 ## Help
 
 ```
-$ protol --help
-Usage: protol [OPTIONS] PROTO_FILES...
+$ protol
+Usage: protol [OPTIONS] COMMAND [ARGS]...
 
-  Rewrite protoc-generated imports for use by the proletariat.
+  Rewrite protoc or buf-generated imports for use by the protoletariat.
 
 Options:
   -g, --generated-python-dir DIRECTORY
                                   Directory containing generated Python code
                                   [required]
-  -p, --proto-path DIRECTORY      Protobuf file search path(s). Accepts
-                                  multiple values.  [required]
-  --overwrite / --no-overwrite    Overwrite all generated Python files with
-                                  modified imports
+  --overwrite / --no-overwrite    Overwrite all relevant files under
+                                  `generated_python_dir`  [default: no-overwrite]
   --create-init / --dont-create-init
-                                  Create an __init__.py file under the
-                                  `generated-python-dir` directory
+                                  Create an empty __init__.py file under
+                                  `generated_python_dir`  [default: dont-create-init]
   --help                          Show this message and exit.
+
+Commands:
+  buf     Use buf to generate the FileDescriptorSet blob
+  protoc  Use protoc to generate the FileDescriptorSet blob
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -152,6 +152,12 @@
               entry = "pyupgrade --py37-plus";
               types = [ "python" ];
             };
+
+            mypy = {
+              enable = true;
+              entry = "mypy";
+              types = [ "python" ];
+            };
           };
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,11 @@
 
         checkInputs = with pkgs; [ buf protobuf ];
 
+        preCheck = ''
+          export HOME
+          HOME="$(mktemp -d)"
+        '';
+
         checkPhase = ''
           runHook preCheck
           pytest

--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,7 @@
 
       devShell = pkgs.mkShell {
         nativeBuildInputs = (with pkgs; [
+          buf
           commitizen
           poetry
           protobuf

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
           }
         );
 
-        checkInputs = [ pkgs.protobuf ];
+        checkInputs = with pkgs; [ buf protobuf ];
 
         checkPhase = ''
           runHook preCheck

--- a/poetry.lock
+++ b/poetry.lock
@@ -359,6 +359,25 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "types-futures"
+version = "3.3.1"
+description = "Typing stubs for futures"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "types-protobuf"
+version = "3.18.1"
+description = "Typing stubs for protobuf"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+types-futures = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.0.0"
 description = "Backported and Experimental Type Hints for Python 3.6+"
@@ -381,7 +400,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"
-content-hash = "df41159cb747b7aabdf9c32b8fe428665a449bf4d690acd20c361ee4013a582f"
+content-hash = "b3181813102ecddaa5b4103f56b17c38947ecb275ebbae571a84128b7b574e2f"
 
 [metadata.files]
 astor = [
@@ -629,6 +648,14 @@ typed-ast = [
     {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
     {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
+]
+types-futures = [
+    {file = "types-futures-3.3.1.tar.gz", hash = "sha256:bbdad92cec642693bac10fbbecf834776009db7782d91dc293bdd123be73186d"},
+    {file = "types_futures-3.3.1-py3-none-any.whl", hash = "sha256:b4bb97d1a028679929a8da2e9e63a5caccc6f68d0d6a456c41fd00e32764f144"},
+]
+types-protobuf = [
+    {file = "types-protobuf-3.18.1.tar.gz", hash = "sha256:6696bf3cabc51dcc076e8de025c405dbdea7488c5268c2febd14527dac82c233"},
+    {file = "types_protobuf-3.18.1-py3-none-any.whl", hash = "sha256:364f6437238a99a2f868bc60777c6a149d8540c902e4dba581ad71e5687735c8"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.0.0-py3-none-any.whl", hash = "sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9"},

--- a/protoletariat/fdsetgen.py
+++ b/protoletariat/fdsetgen.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import abc
+import ast
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Callable, Iterable
+
+import astor
+from google.protobuf.descriptor_pb2 import FileDescriptorSet
+
+from .rewrite import ImportRewriter, build_import_rewrite, register_import_rewrite
+
+_PROTO_SUFFIX_PATTERN = re.compile(r"^(.+)\.proto$")
+
+
+class FileDescriptorSetGenerator(abc.ABC):
+    def __init__(self, fdset_generator_binary: str) -> None:
+        self.fdset_generator_binary = fdset_generator_binary
+
+    @abc.abstractmethod
+    def generate_file_descriptor_set_bytes(self) -> bytes:
+        """Generate the bytes of a `FileDescriptorSet`"""
+
+    def fix_imports(
+        self,
+        generated_python_dir: Path,
+        create_init: bool,
+        overwrite_callback: Callable[[Path, str], None],
+    ) -> None:
+        fdset = FileDescriptorSet.FromString(self.generate_file_descriptor_set_bytes())
+
+        for fd in fdset.file:
+            for dep in fd.dependency:
+                register_import_rewrite(
+                    build_import_rewrite(_PROTO_SUFFIX_PATTERN.sub(r"\1", dep))
+                )
+
+        rewriter = ImportRewriter()
+
+        # only rewrite things with dependencies
+        for fd_name in (fd.name for fd in fdset.file if fd.dependency):
+            name = _PROTO_SUFFIX_PATTERN.sub(r"\1_pb2.py", fd_name)
+            python_file = generated_python_dir.joinpath(name)
+            raw_code = python_file.read_text()
+            module = ast.parse(raw_code)
+            new_module = rewriter.visit(module)
+            new_code = astor.to_source(new_module)
+            overwrite_callback(python_file, new_code)
+
+        if create_init:
+            generated_python_dir.joinpath("__init__.py").touch(exist_ok=True)
+
+
+class Protoc(FileDescriptorSetGenerator):
+    def __init__(
+        self,
+        protoc_path: str,
+        paths: Iterable[Path],
+        proto_paths: Iterable[Path],
+    ) -> None:
+        super().__init__(protoc_path)
+        self.paths = list(paths)
+        self.proto_paths = list(proto_paths)
+
+    def generate_file_descriptor_set_bytes(self) -> bytes:
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            filename = Path(f.name)
+            subprocess.check_output(
+                [
+                    self.fdset_generator_binary,
+                    "--include_imports",
+                    f"--descriptor_set_out={filename}",
+                    *map("--proto_path={}".format, self.proto_paths),
+                    *map(str, self.paths),
+                ]
+            )
+
+        try:
+            return filename.read_bytes()
+        finally:
+            filename.unlink()
+
+
+class Buf(FileDescriptorSetGenerator):
+    def generate_file_descriptor_set_bytes(self) -> bytes:
+        return subprocess.check_output(
+            [
+                self.fdset_generator_binary,
+                "build",
+                "--as-file-descriptor-set",
+                "--output",
+                "-",
+            ]
+        )

--- a/protoletariat/rewrite.py
+++ b/protoletariat/rewrite.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import collections
+import collections.abc
 from typing import Any, Callable, NamedTuple, Sequence, Union
 
 Node = Union[ast.AST, Sequence[ast.AST]]
@@ -13,7 +14,7 @@ class Replacement(NamedTuple):
 
 
 def _is_iterable(value: Any) -> bool:
-    return not isinstance(value, str) and isinstance(value, collections.Iterable)
+    return not isinstance(value, str) and isinstance(value, collections.abc.Iterable)
 
 
 def matches(value: Node, pattern: Node) -> bool:
@@ -33,10 +34,10 @@ def matches(value: Node, pattern: Node) -> bool:
     # recur into lists
     if _is_iterable(value) and _is_iterable(pattern):
         assert isinstance(
-            value, collections.Iterable
+            value, collections.abc.Iterable
         ), f"value is not a non-str iterable {type(value).__name__}"
         assert isinstance(
-            pattern, collections.Iterable
+            pattern, collections.abc.Iterable
         ), f"pattern is not a non-str iterable {type(pattern).__name__}"
         return all(map(matches, value, pattern))
 

--- a/protoletariat/rewrite.py
+++ b/protoletariat/rewrite.py
@@ -13,7 +13,8 @@ class Replacement(NamedTuple):
     new: str
 
 
-def _is_iterable(value: Any) -> bool:
+def _is_iterable(value: Any) -> bool:  # type: ignore[misc]
+    """Return whether `value` is a non-string iterable."""
     return not isinstance(value, str) and isinstance(value, collections.abc.Iterable)
 
 

--- a/protoletariat/rewrite.py
+++ b/protoletariat/rewrite.py
@@ -16,7 +16,7 @@ def _is_iterable(value: Any) -> bool:
     return not isinstance(value, str) and isinstance(value, collections.Iterable)
 
 
-def matches(value: Node, pattern: Node):
+def matches(value: Node, pattern: Node) -> bool:
     """Check whether `value` matches `pattern`.
 
     Parameters

--- a/protoletariat/tests/test_rewrite.py
+++ b/protoletariat/tests/test_rewrite.py
@@ -16,6 +16,11 @@ def check_import_lines(result: Result, expected_lines: Iterable[str]) -> None:
     assert set(expected_lines) <= set(lines)
 
 
+def check_proto_out(out: Path) -> None:
+    assert list(out.rglob("*.py"))
+    assert all(path.read_text() for path in out.rglob("*.py"))
+
+
 @pytest.mark.parametrize(
     ("case", "expected"),
     [
@@ -114,6 +119,8 @@ def test_cli(
             str(out),
         ]
     )
+
+    check_proto_out(out)
 
     result = cli.invoke(
         main,
@@ -273,7 +280,7 @@ def test_example_buf(
         ],
     )
 
-    assert list(out.rglob("*.py"))
+    check_proto_out(out)
 
     result = cli.invoke(
         main,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ name = "protoletariat"
 
 [tool.black]
 line_length = 88
-skip_string_normalization = true
 
 [tool.isort]
 ensure_newline_before_comments = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pydocstyle = "^6.1.1"
 pytest = "^6.2.5"
 pytest-randomly = "^3.10.1"
 pyupgrade = "^2.26.0"
+types-protobuf = "^3.18.1"
 
 [tool.poetry.scripts]
 protol = "protoletariat.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,12 +84,12 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_decorators = true
 # Any handling
-disallow_any_unimported = false
+disallow_any_unimported = true
 disallow_any_expr = false
-disallow_any_decorated = false
-disallow_any_explicit = false
-disallow_any_generics = false
-disallow_subclassing_any = false
+disallow_any_decorated = true
+disallow_any_explicit = true
+disallow_any_generics = true
+disallow_subclassing_any = true
 # None/Optional handling
 no_implicit_optional = true
 # show more context on failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,27 @@ convention = "numpy"
 match_dir = "ibis"
 add_ignore = ["D100", "D101", "D102", "D103", "D104", "D105"]
 
+[tool.mypy]
+ignore_missing_imports = true
+# untyped things
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_decorators = true
+# Any handling
+disallow_any_unimported = false
+disallow_any_expr = false
+disallow_any_decorated = false
+disallow_any_explicit = false
+disallow_any_generics = false
+disallow_subclassing_any = false
+# None/Optional handling
+no_implicit_optional = true
+# show more context on failure
+show_error_context = true
+# show codes in case we end up needing to ignore
+show_error_codes = true
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ line_length = 88
 multi_line_output = 3
 include_trailing_comma = true
 profile = "black"
+skip_glob = [".direnv/*", "result/*", "result-*"]
 
 [tool.pydocstyle]
 inherit = false


### PR DESCRIPTION
- chore: tell prettier to ignore pytest's cache
- build: add types-protobuf to dev deps
- chore: add mypy to pre-commit checks
- chore(dev-deps): add buf to devShell
- refactor: add type annotation to matches function
- style: normalize strings
- test: add buf test
- test: factor out common "out" path check
- fix: remove warning from collections usage
- feat(cli): add support for generating FileDescriptorSet blobs using `buf`
