### PR TITLE
chore(flake/pre-commit-hooks): `50cfce93` -> `c3b4f943`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1636988353,
-        "narHash": "sha256-KZoMUmLgJVYnmohhJ/ENeiH8fCN7rY3VyG/4UpDNEWA=",
+        "lastModified": 1637745948,
+        "narHash": "sha256-DmQG1bZk24eS+BAHwnHPyYIadMLKbq0d1b//iapYIPU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "50cfce93606c020b9e69dce24f039b39c34a4c2d",
+        "rev": "c3b4f94350b0e59c2546fa85890cc70d03616b9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`dd3e1586`](https://github.com/cachix/pre-commit-hooks.nix/commit/dd3e1586243bbd4f0bdf1df1284d22c9b298e72a) | `Support per-hook stages` |