### PR TITLE
chore(flake/poetry2nix): `b23b074f` -> `ac1b5659`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637542143,
-        "narHash": "sha256-DQAksA6Ez8Z8EOZGrPTMAD4XozPgecyzYeRLqBRjj8M=",
+        "lastModified": 1637780720,
+        "narHash": "sha256-yMMcWqW7b6Ifn1v6HZlcNdC+lRpwQL1qJ8MIgtBDGGw=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "b23b074f65a6fdb720aa8ffae1c62d412c1e3db1",
+        "rev": "ac1b5659a34ef343c4503b76e0eacc08de189865",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                    | Commit Message            |
| --------------------------------------------------------------------------------------------------------- | ------------------------- |
| [`27b4c678`](https://github.com/nix-community/poetry2nix/commit/27b4c6784286a1ee0ca7571126d2d9eaa3878a2b) | `overrides: add kerberos` |