### PR TITLE
chore(flake/nixpkgs): `5dadb771` -> `4f326207`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637737052,
-        "narHash": "sha256-6dXZrqIz4TSSHRHDuM3fyTEnF78A3lawM1kKamyRM/4=",
+        "lastModified": 1637780917,
+        "narHash": "sha256-lbdZ/a/dkXz9elnphN2VVtIyLOoGttOZ42txhwgSDNk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5dadb7717f34c2fb95bedc22cf279ef9eb095983",
+        "rev": "4f32620715e5ffe2d0e97a502b6977b76397b8f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`c691e088`](https://github.com/NixOS/nixpkgs/commit/c691e088d79dc154b15568b6dbaece1c1aa473e3) | `bazel_4: Fix Bazel-built protoc segfault on macOS Monterey (#147097)` |
| [`86c48e88`](https://github.com/NixOS/nixpkgs/commit/86c48e88b08e976f258775394a1901d33a66968a) | `nim_builder: do not use output* env variables`                        |
| [`4a22fd0d`](https://github.com/NixOS/nixpkgs/commit/4a22fd0d8fb38f7bfd804a52b2ddccfc8ba958ee) | `dhallPackages.dhall-grafana: Small simplification`                    |
| [`3721ed20`](https://github.com/NixOS/nixpkgs/commit/3721ed202f5bdfe688eaea47b9821453737ba1a8) | `buildbot: 3.3.0 -> 3.4.0`                                             |
| [`020812f3`](https://github.com/NixOS/nixpkgs/commit/020812f37cb2cf52189ce66d06dce33c506deba6) | `python3Packages.pyramid_mako: fix compatibility with pyramid>=2.0`    |
| [`7dbdc0df`](https://github.com/NixOS/nixpkgs/commit/7dbdc0df772cd2d20df60f8683cf8b3f6f1e2bd9) | `corrosion: unstable-2021-02-23 -> unstable-2021-11-23 (#147244)`      |
| [`c4d7b1c5`](https://github.com/NixOS/nixpkgs/commit/c4d7b1c52edf34e1db4338fce05213c944b865b3) | `spice: manually add file missing from tarball`                        |
| [`1df50b47`](https://github.com/NixOS/nixpkgs/commit/1df50b478af99ea8d6f524e05b6c0ecb05e33ad4) | `spice: remove use celt051 option`                                     |
| [`b8f02324`](https://github.com/NixOS/nixpkgs/commit/b8f02324465c734d4990c9cd3e267b5abb63cb16) | `exploitdb: 2021-11-23 -> 2021-11-24`                                  |
| [`e7a0a3bb`](https://github.com/NixOS/nixpkgs/commit/e7a0a3bb821ec477af2462dc1a21c425945a2ae7) | `python39Packages.hacking: disable failing lint test`                  |
| [`40915ab8`](https://github.com/NixOS/nixpkgs/commit/40915ab80fd90a4a9c4aed05613f45894b6fe5dc) | `terraform-providers: Update alicloud to v1.144.0`                     |
| [`63a61947`](https://github.com/NixOS/nixpkgs/commit/63a61947b9bb1fef05ebeead5f43c2c1d2a7cc83) | `htop-vim: add meta.mainProgram`                                       |
| [`54514c38`](https://github.com/NixOS/nixpkgs/commit/54514c38a45e0a6427b5a2045cd8b83d11b5d63b) | `watchdog: mark as unbroken on aarch64-darwin`                         |
| [`2dbcf921`](https://github.com/NixOS/nixpkgs/commit/2dbcf92154f32989374dd1167b46c57e3e3750fc) | `python3Packages.discordpy: relax aiohttp constraint`                  |
| [`e73fecb2`](https://github.com/NixOS/nixpkgs/commit/e73fecb25708b648d28bf700679cda5b5c91dcf2) | `python3Packages.angrop: 9.0.10576 -> 9.0.10651`                       |
| [`c3fa6539`](https://github.com/NixOS/nixpkgs/commit/c3fa6539190477516dc2d97d6ba98f080e72c9d0) | `python3Packages.angr: 9.0.10576 -> 9.0.10651`                         |
| [`6b00dd21`](https://github.com/NixOS/nixpkgs/commit/6b00dd2166fa9ef21cd9892383cab59edbd2a1b7) | `python3Packages.cle: 9.0.10576 -> 9.0.10651`                          |
| [`a1d4ddd7`](https://github.com/NixOS/nixpkgs/commit/a1d4ddd74c1ffdcae21e5c6134c4793bb0c7582b) | `python3Packages.claripy: 9.0.10576 -> 9.0.10651`                      |
| [`2e70eaba`](https://github.com/NixOS/nixpkgs/commit/2e70eaba891d841d75cdfbe22a44bbf9a11d6a39) | `python3Packages.pyvex: 9.0.10576 -> 9.0.10651`                        |
| [`9dc565d4`](https://github.com/NixOS/nixpkgs/commit/9dc565d4d5e8cc93e532000cb966d72f0e5de54f) | `python3Packages.ailment: 9.0.10576 -> 9.0.10651`                      |
| [`d9681633`](https://github.com/NixOS/nixpkgs/commit/d9681633f8fa12721157ddc8d53ca6ad93b88abf) | `python3Packages.archinfo: 9.0.10576 -> 9.0.10651`                     |
| [`c32095b4`](https://github.com/NixOS/nixpkgs/commit/c32095b400076b89d63920805dc95533607e78d2) | `ghcWithPackages: rename withLLVM to useLLVM`                          |
| [`1071e6f6`](https://github.com/NixOS/nixpkgs/commit/1071e6f66776344eedc810d57a4f805bc5d0f915) | `python3Packages.python-opendata-transport: 0.2.2 -> 0.3.0`            |
| [`6dc2edb8`](https://github.com/NixOS/nixpkgs/commit/6dc2edb831d1abd552cf6407509aae71bb060626) | `python3.pkgs.pandas: remove optional dependencies`                    |
| [`a7f2cd86`](https://github.com/NixOS/nixpkgs/commit/a7f2cd867ac5a903c01d2f9a41542cac18b3853f) | `xorg.xf86videoqxl: patch build after `bool` rename`                   |
| [`45372045`](https://github.com/NixOS/nixpkgs/commit/4537204529edf803bc136ae5b3bceaaa90506013) | `python3Packages.pyhaversion: 21.10.0 -> 21.11.1`                      |
| [`0649fcdf`](https://github.com/NixOS/nixpkgs/commit/0649fcdf26b0b6b5a7029fa2f2553fe9a24882a2) | `xorg.xorgserver: apply upstream patch`                                |
| [`d051071e`](https://github.com/NixOS/nixpkgs/commit/d051071e20797d279163dda285c61edbbd53eaa0) | `Update pkgs/development/tools/dtools/default.nix`                     |
| [`40c3bc3b`](https://github.com/NixOS/nixpkgs/commit/40c3bc3b0876f82b7ebf6816ab32a3c0c6e91133) | `pytho3Packages.m3u8: use upstream patch (#147163)`                    |
| [`55659617`](https://github.com/NixOS/nixpkgs/commit/5565961762f118e44b3949621cbde4e0dd41f26b) | `python3Packages.glances-api: 0.2.1 -> 0.3.2`                          |
| [`1722f697`](https://github.com/NixOS/nixpkgs/commit/1722f697f878e302d5c4a0b0d23aa59170c3ca01) | `python3Packages.imap-tools: 0.50.0 -> 0.50.1`                         |
| [`894e594d`](https://github.com/NixOS/nixpkgs/commit/894e594d04350f09ee901692fcece52752824963) | `dtools: Fix aarch64-darwin build`                                     |
| [`e171a2fb`](https://github.com/NixOS/nixpkgs/commit/e171a2fb9cd10dda1d225698e8a68a8e4f01d7ad) | `python3Packages.pyzerproc: 0.4.9 -> 0.4.10`                           |
| [`3ba46c54`](https://github.com/NixOS/nixpkgs/commit/3ba46c54f909ad9e7a658e561ffa65e226b30faa) | `python3Packages.pykulersky: 0.5.2 -> 0.5.3`                           |
| [`d442ca39`](https://github.com/NixOS/nixpkgs/commit/d442ca39dcf4095d16e46d8c56ac84fafa6788c6) | `haskellPackages: mark builds failing on hydra as broken`              |
| [`ee0a2c93`](https://github.com/NixOS/nixpkgs/commit/ee0a2c935f115616dfa4ee21cf236f3cf1d3b82a) | `haskellPackages.hls-rename-plugin: allow compiling with ghcide 1.5.0` |
| [`3e58edbf`](https://github.com/NixOS/nixpkgs/commit/3e58edbf2805c518a81f7a0d9a7d52c5c56ae7cb) | `kops: 1.21.4 -> 1.22.2`                                               |
| [`1796d5fe`](https://github.com/NixOS/nixpkgs/commit/1796d5fe3ce16df8949a89688e68dadf649c175f) | `kops: 1.21.1 -> 1.21.4`                                               |
| [`3afcb1b9`](https://github.com/NixOS/nixpkgs/commit/3afcb1b98534af50f436774230f511bab045ea83) | `kops: 1.20.2 -> 1.20.3`                                               |
| [`c2a3cb84`](https://github.com/NixOS/nixpkgs/commit/c2a3cb84430b0264b431a66b12c1824ef3ad771c) | `gdu: 5.10.0 -> 5.10.1`                                                |
| [`d1d48675`](https://github.com/NixOS/nixpkgs/commit/d1d48675c4e42fb03294188ec3ee25b6c5ef0773) | `varnish70: 7.0.0 -> 7.0.1`                                            |
| [`065992e4`](https://github.com/NixOS/nixpkgs/commit/065992e4f88361938844e37decbe471228566bae) | `mosquitto: use libwebsockets 4.x`                                     |
| [`2f98c182`](https://github.com/NixOS/nixpkgs/commit/2f98c1824c750c2d0c6440b8c57a039092cb0cd3) | `ghcWithPackages: GHC 8.10.7 still needs LLVM for aarch64-darwin`      |
| [`03cdef15`](https://github.com/NixOS/nixpkgs/commit/03cdef15d45d6d2bd043a35de1baed559df7dcf9) | `gitlab-runner: 14.4.0 -> 14.5.0`                                      |
| [`1075e30c`](https://github.com/NixOS/nixpkgs/commit/1075e30c926488739d43bb3c307d7db0544a1079) | `openvscode-server: 1.62.0 -> 1.62.3`                                  |
| [`024268ca`](https://github.com/NixOS/nixpkgs/commit/024268ca257fd296b32c8723b4fb04d461fbbffe) | `python3Packages.dsmr-parser: 0.30 -> 0.31`                            |
| [`2bb4481f`](https://github.com/NixOS/nixpkgs/commit/2bb4481f32b56526bb214b9e03f25fe175a006cc) | `qcengine: 0.20.1 -> 0.21.0`                                           |
| [`51f4d2d2`](https://github.com/NixOS/nixpkgs/commit/51f4d2d2cd98f940f0baac3fb4f600036cf56ea8) | `python3.pkgs.qcelemental: 0.23.0 -> 0.24.0`                           |
| [`dacb164d`](https://github.com/NixOS/nixpkgs/commit/dacb164dff3a365d0702290e6bf32e79b07904f2) | `btcpayserver: 1.3.3 -> 1.3.6`                                         |
| [`f10d0800`](https://github.com/NixOS/nixpkgs/commit/f10d080046e9aafa52c04b99624507d9bada0130) | `nbxplorer: 2.2.16 -> 2.2.18`                                          |
| [`c59944cf`](https://github.com/NixOS/nixpkgs/commit/c59944cf27130bc4c5a7d6c91013c452c9372856) | `gitlab-runner: don't bundle prebuilt docker images`                   |
| [`86c50292`](https://github.com/NixOS/nixpkgs/commit/86c50292b0540dd1cb16636342c938dd9ee5db42) | `haskellPackages.hls-haddock-comment-plugin: no aarch64-linux tests`   |
| [`d5d6cc72`](https://github.com/NixOS/nixpkgs/commit/d5d6cc7262726c10ac6b7ed7dbc01ed363b008f5) | `python3Packages.autobahn: 21.3.1 -> 21.11.1`                          |
| [`8c17cc99`](https://github.com/NixOS/nixpkgs/commit/8c17cc993b8b3d374944f7c6f04663e2047b6128) | `ghcHEAD: fix mingw build`                                             |
| [`90abe1c0`](https://github.com/NixOS/nixpkgs/commit/90abe1c0c62d790be66e789e4e9037065bc46459) | `haskellPackages.hls-hlint-plugin: don't run tests on aarch64-linux`   |
| [`57017e53`](https://github.com/NixOS/nixpkgs/commit/57017e53520b1d7151f5c95f3c9a1ca435e126ac) | `haskellPackages.melf: don't attempt to run incomplete test suite`     |
| [`a86917fe`](https://github.com/NixOS/nixpkgs/commit/a86917fe5e3ca3ac80a17b083cd373727ba4cae2) | `haskellPackages.dear-imgui: jailbreak to fix build`                   |
| [`885ad7c3`](https://github.com/NixOS/nixpkgs/commit/885ad7c36776377d97c8cb5f6fe055af1f561f64) | `haskellPackages: restrict haskell-gi's revdeps to be 0.25 compatible` |
| [`3c0b2ca7`](https://github.com/NixOS/nixpkgs/commit/3c0b2ca7b300fee6c13ec770bddb747c49f4eb7d) | `haskellPackages.hls-hlint-plugin: don't run tests on aarch64-linux`   |
| [`1606d449`](https://github.com/NixOS/nixpkgs/commit/1606d449ff752f1729d3d5a19533cb1b153d771e) | `haskell.packages.ghc921.vector-th-unbox: drop now obsolete patch`     |
| [`6b3cbce9`](https://github.com/NixOS/nixpkgs/commit/6b3cbce94f20cafa63e5a1c8cb045e8fe223600c) | `haskell.packages.ghc921.streaming-commons: drop now obsolete patch`   |
| [`060b13e4`](https://github.com/NixOS/nixpkgs/commit/060b13e415c50df92d0b070e441109721462a2af) | `haskellPackages.git-annex: drop patch included in latest release`     |
| [`13943f5d`](https://github.com/NixOS/nixpkgs/commit/13943f5dc53ce474568769d77b96a022199161d8) | `openh264: support cross-compilation`                                  |
| [`40ea5fe6`](https://github.com/NixOS/nixpkgs/commit/40ea5fe6d14c628f076f7386a29adab8aa7c67a0) | `haskellPackages.git-annex: update sha256 for 8.20211117`              |
| [`344bea4e`](https://github.com/NixOS/nixpkgs/commit/344bea4e0c7deaf043e85c03968954f74838b6e8) | `haskell.packages.ghc921.aeson_2_0_1_0: drop obsolete override`        |
| [`0bebef94`](https://github.com/NixOS/nixpkgs/commit/0bebef945bd252e7fd8e855a406e44cf684d33f8) | `haskell.packages.ghcHEAD.git-annex: drop outdated override`           |
| [`af3fa3e2`](https://github.com/NixOS/nixpkgs/commit/af3fa3e279e7214f44fd3ec466d0f3ce723eceb1) | `haskell.packages.ghc9{0,2}1.lens: 5.0.1 -> 5.1`                       |
| [`32508c31`](https://github.com/NixOS/nixpkgs/commit/32508c31452b5fb58a3830dc917db24cc2a02f7b) | `haskellPackages.hls-brittany-plugin: dontCheck on aarch64`            |
| [`4e89efee`](https://github.com/NixOS/nixpkgs/commit/4e89efeed0824f9b02666faa50a59338a3f04977) | `htop-vim: init at unstable-2021-10-11`                                |
| [`356698c4`](https://github.com/NixOS/nixpkgs/commit/356698c493e1b237827e2793ade98f37964b3aff) | `haskell-language-server: Fix plugins for 1.5.0.0`                     |
| [`e69353aa`](https://github.com/NixOS/nixpkgs/commit/e69353aaf70db2f12cd3ceb177ac6dd7305cda80) | `haskellPackages.doctest_0_18_2: init at 0.18.2`                       |
| [`781daa41`](https://github.com/NixOS/nixpkgs/commit/781daa41ef81234d8e1b8660cb7a163b34e15593) | `haskellPackages: adapt to hspec hackage update`                       |
| [`6f0f4a92`](https://github.com/NixOS/nixpkgs/commit/6f0f4a92b55ab3c002ffb83cb36f5938ab3a37cf) | `haskellPackages.xmonad-contrib_0_17_0: build with matching xmonad`    |
| [`7fc57e61`](https://github.com/NixOS/nixpkgs/commit/7fc57e61d317295999c2b2cddcf3cc3ffdfeb57c) | `haskellPackages: regenerate package set based on current config`      |
| [`e8f81dc1`](https://github.com/NixOS/nixpkgs/commit/e8f81dc183d0e9705b47853d924b17d98f4336ea) | `all-cabal-hashes: 2021-11-12T03:22:57Z -> 2021-11-18T20:32:52Z`       |
| [`bea36e4f`](https://github.com/NixOS/nixpkgs/commit/bea36e4f8a52060c4d6a2416086a535146643b87) | `haskellPackages: stackage-lts 18.16 -> 18.17`                         |
| [`571f3e50`](https://github.com/NixOS/nixpkgs/commit/571f3e504bf504844e8705d52f8552d6b6d115d4) | `ghcWithPackages: list missing targets with NCG available`             |
| [`cfdc073d`](https://github.com/NixOS/nixpkgs/commit/cfdc073da4cf663327bd708a81e87ed326d2b878) | `ghcWithPackages: check targetPlatform to decide if NCG is available`  |
| [`907ac614`](https://github.com/NixOS/nixpkgs/commit/907ac61491a228a85d7669b9e6b518af9b370fdd) | `translate-shell: fixed indentation in default.nix`                    |
| [`9e2669e4`](https://github.com/NixOS/nixpkgs/commit/9e2669e4cdafaa28d444793cfb9031188b2ead59) | `translate-shell: added missing dependency on hexdump`                 |
| [`422e19f7`](https://github.com/NixOS/nixpkgs/commit/422e19f7fe72a9d6473e6abf55e2983031733ed5) | `firefox-devedition-bin: 94.0b2 -> 95.0b3`                             |
| [`4b92778d`](https://github.com/NixOS/nixpkgs/commit/4b92778d544abfd49c5876932ed185612b1cf2cd) | `firefox-beta-bin: 94.0b2 -> 95.0b3`                                   |