### PR TITLE
chore(flake/nixpkgs): `4f326207` -> `38116953`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637780917,
-        "narHash": "sha256-lbdZ/a/dkXz9elnphN2VVtIyLOoGttOZ42txhwgSDNk=",
+        "lastModified": 1637824528,
+        "narHash": "sha256-3lfPZTDjM/vi2+u54xm26NcaBc4z09M1dqF/cQioaLY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f32620715e5ffe2d0e97a502b6977b76397b8f8",
+        "rev": "38116953c2e19e3df828b9b6e2dc7d47a99b57ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`1eeffcbc`](https://github.com/NixOS/nixpkgs/commit/1eeffcbc01300669c87d5e648af14fbe7eb633f1) | `ArchiSteamFarm: fix build`                                                  |
| [`a988b71a`](https://github.com/NixOS/nixpkgs/commit/a988b71a096dae615358d60d95ca02c1da454d97) | `plasma-hud: init at 19.10.1 (#74085)`                                       |
| [`31b46dd7`](https://github.com/NixOS/nixpkgs/commit/31b46dd7f9af9c4360c5796a885c8ec7e8594e51) | `delta: add SuperSandro2000 as maintainer`                                   |
| [`6901a575`](https://github.com/NixOS/nixpkgs/commit/6901a575abb04c27427caff00a6a557ef74d11d0) | `pmbootstrap: 1.30.0 -> 1.39.0 (#146576)`                                    |
| [`122b0e06`](https://github.com/NixOS/nixpkgs/commit/122b0e0602357370b6d15fcbc7c487a3116d1be5) | `delta: 0.9.2 -> 0.10.0`                                                     |
| [`d9e78207`](https://github.com/NixOS/nixpkgs/commit/d9e78207b6f1588e210006cd4c94c8633aa57e06) | `yoda: 1.9.2 -> 1.9.3`                                                       |
| [`a9868c30`](https://github.com/NixOS/nixpkgs/commit/a9868c307d849900c33bea8f48939d0cb3d48235) | `python3Packages.python-smarttub: relax aiohttp constraint`                  |
| [`e5f9c521`](https://github.com/NixOS/nixpkgs/commit/e5f9c5215ae48e0f0373787bb56c5deddbe2d9fb) | `hilbish: 0.6.1 -> 0.7.1`                                                    |
| [`942f57e7`](https://github.com/NixOS/nixpkgs/commit/942f57e79b6453d0efca677bf1094abc3a7f65d2) | `nixos/acme: add an option for reloading systemd services after renewal`     |
| [`c85680db`](https://github.com/NixOS/nixpkgs/commit/c85680db4fb2137cad8e2395c02d2ad4a5af59cc) | `mpvScripts.video-cutter: init at unstable-2021-02-03`                       |
| [`4d5ee723`](https://github.com/NixOS/nixpkgs/commit/4d5ee723545c4aac8cadd8fba3e8b8ee2d25fb04) | `keepass-charactercopy: init at 1.0.0`                                       |
| [`0e0b0835`](https://github.com/NixOS/nixpkgs/commit/0e0b0835865c65321d9159d09a86eba1665acb13) | `keepass-qrcodeview: init at 1.0.4`                                          |
| [`a795b945`](https://github.com/NixOS/nixpkgs/commit/a795b94566c7ad2e698a28fa95e2736b30029f5f) | `keepass-keetraytotp: init at 0.108.0`                                       |
| [`c18638dc`](https://github.com/NixOS/nixpkgs/commit/c18638dc95216b1b2930d16e1334613d82d05e8e) | `cfm: init at 0.6.6`                                                         |
| [`cddf831b`](https://github.com/NixOS/nixpkgs/commit/cddf831b303d9fa99a7fcfda4868a6959cdf8aac) | `intel-media-driver: 21.4.1 -> 21.4.2`                                       |
| [`f9212df9`](https://github.com/NixOS/nixpkgs/commit/f9212df975949c4a42fd53a4c691faf6eb8b09db) | `gnome.sushi: Enable more codecs`                                            |
| [`fda27cf3`](https://github.com/NixOS/nixpkgs/commit/fda27cf38e94511f8b8ee091e7189375493dec74) | `gnome.sushi: Fix runtime`                                                   |
| [`62575c66`](https://github.com/NixOS/nixpkgs/commit/62575c66e6a25cd3b11b5fdf74ce1a930eac2591) | `python3Packages.devolo-plc-api: 0.6.3 -> 0.6.4`                             |
| [`7457e3fb`](https://github.com/NixOS/nixpkgs/commit/7457e3fb772be161606405f0137fe5ccd6fc5e6f) | `python3Packages.starkbank-ecdsa: 2.0.2 -> 2.0.3`                            |
| [`d91ef9f8`](https://github.com/NixOS/nixpkgs/commit/d91ef9f8b9c7c6fec5c2a7c612fe02eb89985c1e) | `python3Packages.slack-sdk: 3.11.2 -> 3.12.0`                                |
| [`caa7aa15`](https://github.com/NixOS/nixpkgs/commit/caa7aa15abb8fde128efa69ed342c033633ca794) | `python3Packages.types-pytz: 2021.3.0 -> 2021.3.1`                           |
| [`e19be477`](https://github.com/NixOS/nixpkgs/commit/e19be4776e3ba84d17b29efe161484642938e535) | `python3Packages.types-setuptools: 57.4.2 -> 57.4.3`                         |
| [`934d8877`](https://github.com/NixOS/nixpkgs/commit/934d88778256c9564f7d061e4923c69eff16cb40) | `checkov: 2.0.598 -> 2.0.603`                                                |
| [`2d083acf`](https://github.com/NixOS/nixpkgs/commit/2d083acf666f7f7c7a4ca6e5c665207aa58d1ba2) | `tribler: 7.4.4 -> 7.10.0`                                                   |
| [`97e808fe`](https://github.com/NixOS/nixpkgs/commit/97e808fecf8e348f09490bd3fe31458906740a46) | `maintainers: add taikx4`                                                    |
| [`16254697`](https://github.com/NixOS/nixpkgs/commit/162546972b659f74de08cd4a73c75040c0b2f8f8) | `radeontop: 1.3 -> 1.4`                                                      |
| [`7e43f2f8`](https://github.com/NixOS/nixpkgs/commit/7e43f2f8500441e93a2fe75cb4ce5183d7eacca3) | `pantheon.elementary-dock: unstable-2021-07-16 -> unstable-2021-11-08`       |
| [`87a5c671`](https://github.com/NixOS/nixpkgs/commit/87a5c67107cd6b803c743e55664bdd7319c3eb8f) | `pantheon.elementary-icon-theme: 6.0.0 -> 6.1.0`                             |
| [`2361a737`](https://github.com/NixOS/nixpkgs/commit/2361a73786b9c6eb125aaf31a2ae0b3a331f131b) | `pantheon.elementary-gtk-theme: 6.1.0 -> 6.1.1`                              |
| [`110e1931`](https://github.com/NixOS/nixpkgs/commit/110e1931cec2162d4976a44382d43e5f445c32cb) | `pantheon.granite: 6.1.2 -> 6.2.0`                                           |
| [`e5afe95f`](https://github.com/NixOS/nixpkgs/commit/e5afe95fe7d4e2028741a3721eeb846e328925dd) | `pantheon.switchboard-plug-pantheon-shell: 6.0.0 -> 6.1.0`                   |
| [`a9f302e1`](https://github.com/NixOS/nixpkgs/commit/a9f302e1a2dedd1ea74f9bc847c2aac1515da3e5) | `pantheon.elementary-onboarding: 6.0.0 -> 6.1.0`                             |
| [`59c9786c`](https://github.com/NixOS/nixpkgs/commit/59c9786c5be350cb2838ca63f88b63819b997b1b) | `pantheon.appcenter: 3.8.2 -> 3.9.0`                                         |
| [`884945d6`](https://github.com/NixOS/nixpkgs/commit/884945d69c24f82741f2b30a0d4eddced68123c3) | `pantheon.switchboard-plug-security-privacy: 2.2.5 -> 2.3.0`                 |
| [`079cbad8`](https://github.com/NixOS/nixpkgs/commit/079cbad8d958e9f6835dbfc401462d100e11de2f) | `pantheon.elementary-camera: 6.0.1 -> 6.0.2`                                 |
| [`26c04f99`](https://github.com/NixOS/nixpkgs/commit/26c04f9942bc8d462cef49e321ca470f17afb159) | `pantheon.wingpanel-indicator-network: 2.3.1 -> 2.3.2`                       |
| [`f3b5da17`](https://github.com/NixOS/nixpkgs/commit/f3b5da17e8501ec8279c3daead6bc41f1ec56cf8) | `pantheon.switchboard-plug-keyboard: 2.5.1 -> 2.6.0`                         |
| [`156d8d61`](https://github.com/NixOS/nixpkgs/commit/156d8d619c727351d40ba67df60521b33698bf0c) | `haskell.compiler.*: be clear about LLVM build->target role`                 |
| [`96e5b267`](https://github.com/NixOS/nixpkgs/commit/96e5b267fde523b75df3e0177ffee250604e8cd0) | `pantheon.switchboard-plug-sound: 2.2.7 -> 2.3.0`                            |
| [`01296d77`](https://github.com/NixOS/nixpkgs/commit/01296d775d65f90688ada5df535ece01ab958596) | `python3Packages.pyeclib: fix for darwin`                                    |
| [`9571ac96`](https://github.com/NixOS/nixpkgs/commit/9571ac967f3b186f866eb9ea11522a1ed57eeb51) | `phpExtensions.gnupg: init at 1.5.0`                                         |
| [`c7d9223c`](https://github.com/NixOS/nixpkgs/commit/c7d9223c5d3a3d3e47d990db7cebebe89343dc32) | `Add aarch64-darwin to platforms list`                                       |
| [`5c706a49`](https://github.com/NixOS/nixpkgs/commit/5c706a49a629cfe97386a95907c811975ba1f62b) | `mpv: inherit meta from mpv-unwrapped`                                       |
| [`62b0f436`](https://github.com/NixOS/nixpkgs/commit/62b0f43687de76da51e15a9d5c9cc9acf5ff902a) | `google-cloud-sdk: 364.0.0 -> 365.0.0`                                       |
| [`9c800811`](https://github.com/NixOS/nixpkgs/commit/9c8008113a36dab9e5c70006c643d14e61a5465a) | `google-cloud-sdk: add update script`                                        |
| [`b05a2021`](https://github.com/NixOS/nixpkgs/commit/b05a202159c41ccc4cc9d3fed77801235cbcf3a7) | `xh: 0.13.0 -> 0.14.0`                                                       |
| [`90f1a0aa`](https://github.com/NixOS/nixpkgs/commit/90f1a0aaa4878e8c628f80e1cf85661fc5bc0b96) | `audiosprite: init at 0.7.2`                                                 |
| [`a6c95f27`](https://github.com/NixOS/nixpkgs/commit/a6c95f2706b1e8ef7888b040abd4dd6a411460a4) | `python3Packages.nbclient: 0.5.8 -> 0.5.9`                                   |
| [`9cda0f4f`](https://github.com/NixOS/nixpkgs/commit/9cda0f4f61cb05b2465d3b6c51735a4921f0bfbe) | `mono-dll-fixer: remove builder.sh`                                          |
| [`a4dc11fd`](https://github.com/NixOS/nixpkgs/commit/a4dc11fd99afb6ed7aa794e698a0bd5975cb979f) | `yaggo: init at 1.5.10`                                                      |
| [`b897f5fe`](https://github.com/NixOS/nixpkgs/commit/b897f5fe70450cd20a4118311e7d1e6b2bfa90bf) | `nixos/autosuggestions: add config to control whether suggestions are async` |
| [`42cc440e`](https://github.com/NixOS/nixpkgs/commit/42cc440eedadfd9a90055a0d82cd2a1df12be222) | `notion-app-enhanced: init at 2.0.16-5`                                      |
| [`ecb8ece3`](https://github.com/NixOS/nixpkgs/commit/ecb8ece3488d5d81ed58e246ac1348ee4a5bef3a) | `maintainers: add tmarkovski`                                                |
| [`d87cb1d3`](https://github.com/NixOS/nixpkgs/commit/d87cb1d3c8e4f898b88b23df98fc99fb172c9d46) | `trinsic-cli: init at 1.1.0`                                                 |
| [`f53facb9`](https://github.com/NixOS/nixpkgs/commit/f53facb97c3c19c4eaa7806d0e617d439fe66954) | `nrm: init at 1.2.5`                                                         |
| [`39785d31`](https://github.com/NixOS/nixpkgs/commit/39785d319321921e9eac7db9ce4e52ce562b63c4) | `python3Packages.srpenergy: 1.3.2 -> 1.3.5`                                  |
| [`5b6133b5`](https://github.com/NixOS/nixpkgs/commit/5b6133b57611c359d3139996b4ac193b5663c76f) | `python3Packages.vilfo-api-client: 0.3.3 -> 0.4.1`                           |
| [`317c885a`](https://github.com/NixOS/nixpkgs/commit/317c885a43e9976a17f017989be18378e4cd7fb0) | `postman: 9.1.1 -> 9.1.4`                                                    |
| [`4e2839f0`](https://github.com/NixOS/nixpkgs/commit/4e2839f091ecc729fb38d61f26199a6c0aced4ce) | `pythonPackges.typical: init at 2.7.9`                                       |
| [`af148b96`](https://github.com/NixOS/nixpkgs/commit/af148b967c33a2c301b52dfb44f5110a25aa9433) | `pythonPackages.future-typing: init at 0.4.1`                                |
| [`30027eb7`](https://github.com/NixOS/nixpkgs/commit/30027eb71f7e660456b0a263fd79198d0383f0f4) | `google-cloud-sdk: 362.0.0 -> 364.0.0`                                       |
| [`05efb8ed`](https://github.com/NixOS/nixpkgs/commit/05efb8ed913d5b0eee3736652fb91befc5e04233) | `build-support/rust/sysroot/src: Use `dont*` instead of phase list`          |
| [`c9c3de01`](https://github.com/NixOS/nixpkgs/commit/c9c3de0131c565bf5a7f0e2249cd26f6e7acb172) | `Update script as rust-src layout has changed`                               |
| [`cbd00bab`](https://github.com/NixOS/nixpkgs/commit/cbd00bab803b03cacbea27d442c60e719a804992) | `build-support/rust: Split out sysroot src derivation`                       |
| [`2c7f6237`](https://github.com/NixOS/nixpkgs/commit/2c7f62379f7c65d573892ba89eefb5631d721ba8) | `rustcSrc: Reduce duplication`                                               |
| [`548d58d7`](https://github.com/NixOS/nixpkgs/commit/548d58d7a0f2281f001e44497f81e862567d80f6) | `pythonPackages.flask-httpauth: 4.4.0 -> 4.5.0`                              |