### PR TITLE
chore(flake/nixpkgs): `38116953` -> `07e3b292`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637824528,
-        "narHash": "sha256-3lfPZTDjM/vi2+u54xm26NcaBc4z09M1dqF/cQioaLY=",
+        "lastModified": 1637871473,
+        "narHash": "sha256-Qn5/H/m8F0zTWUOMcywH5DQLD3HPCJj/OHz+7f5EMqc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "38116953c2e19e3df828b9b6e2dc7d47a99b57ce",
+        "rev": "07e3b29217491dcee2c8e71d8da764342cd414d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`4b5c3d93`](https://github.com/NixOS/nixpkgs/commit/4b5c3d9376a829f454d195d0c8053a160f6b4fbe) | `qemu: only include alsa-lib for alsa support`                               |
| [`5d9e0f86`](https://github.com/NixOS/nixpkgs/commit/5d9e0f86b9883ab309acaa6607a9dc0e7372ad2b) | `qemu: never use bundled Meson`                                              |
| [`0b12f0c1`](https://github.com/NixOS/nixpkgs/commit/0b12f0c1c93664bcf82a95e4746446cbf7d5a27c) | `antlr4: install CMake config files`                                         |
| [`856ce74b`](https://github.com/NixOS/nixpkgs/commit/856ce74b013135319c376a890ada14308ae1900b) | `nix-eval-jobs: switch to nix stable`                                        |
| [`7c52900a`](https://github.com/NixOS/nixpkgs/commit/7c52900af1e07e105c90c457a7069acd45a96be0) | `coqPackages.coq-record-update: init`                                        |
| [`8b2fe80d`](https://github.com/NixOS/nixpkgs/commit/8b2fe80dd2703211ba4e7d00dba3b1ed26fc01cb) | `maintainers: add ineol`                                                     |
| [`9aecabdf`](https://github.com/NixOS/nixpkgs/commit/9aecabdf89ba3ebdc556e6d74a93604ad198e97b) | `protoc-gen-go-vtproto: init at 0.2.0 (#144449)`                             |
| [`9974c0df`](https://github.com/NixOS/nixpkgs/commit/9974c0dfde44999658c902d30798717fdb367c9e) | `cargo-flash: 0.11.0 -> 0.12.0`                                              |
| [`a5c0f59b`](https://github.com/NixOS/nixpkgs/commit/a5c0f59bf732419674e15bed4188a6c0e881116e) | `buildGraalvmNativeImage: allow nativeImageBuildArgs to be overwritten`      |
| [`52ece396`](https://github.com/NixOS/nixpkgs/commit/52ece396d74fa87ace36c5e861b5e9fe7a4aa961) | `python3Packages.surepy: relax constraints`                                  |
| [`ca71d0b2`](https://github.com/NixOS/nixpkgs/commit/ca71d0b22a47e07bfe0008737e238fd50e27b83b) | `pantheon.wingpanel-indicator-datetime: use upstreamed patch`                |
| [`a54db166`](https://github.com/NixOS/nixpkgs/commit/a54db1668b888c1f6dddd8c644b203df21697088) | `pantheon.wingpanel-applications-menu: 2.9.1 -> 2.10.1`                      |
| [`d5aaed53`](https://github.com/NixOS/nixpkgs/commit/d5aaed533cb321c2e12182f811fe28401df3fb5d) | `pantheon.gala: 6.2.1 -> 6.3.0`                                              |
| [`b9f2c542`](https://github.com/NixOS/nixpkgs/commit/b9f2c542ba87f7d668e1799b24340fe9c1b57eed) | `deno: 1.16.2 -> 1.16.3`                                                     |
| [`80f5a12f`](https://github.com/NixOS/nixpkgs/commit/80f5a12fa3e39789fe51e832385c39104b7d6fa3) | `jetbrains.datagrip: 2021.2.4 -> 2021.3.1`                                   |
| [`e480a2f4`](https://github.com/NixOS/nixpkgs/commit/e480a2f43062e01bfee27a3139f09ad852299617) | `python3Packages.rflink: add patch to support async_timeout> 4`              |
| [`28b5d59d`](https://github.com/NixOS/nixpkgs/commit/28b5d59de2cbf34cc7af759b01b808a04777a15f) | `megasync: 4.5.3.0 -> 4.6.1.0`                                               |
| [`8efc68c0`](https://github.com/NixOS/nixpkgs/commit/8efc68c03f4a34004e71b57050edd44b4fecaeee) | `syncthing: 1.18.3 -> 1.18.4`                                                |
| [`7d07b8dd`](https://github.com/NixOS/nixpkgs/commit/7d07b8dd6cff0c04dbd839e4709675c43ceb4964) | `python3Packages.rokuecp: disable failing test`                              |
| [`c1eb0ddd`](https://github.com/NixOS/nixpkgs/commit/c1eb0dddea79c5b5911dc1bb818378abda2cdedf) | `delly: 0.8.7 -> 0.9.1`                                                      |
| [`ebee4b00`](https://github.com/NixOS/nixpkgs/commit/ebee4b009010381d5ca0282f7f24a183ea2d528f) | `python3Packages.pyatv: remove version pinning`                              |
| [`b5d3526b`](https://github.com/NixOS/nixpkgs/commit/b5d3526bab47eb008b2183438e22165da8cfb84e) | `tlaplus: 1.7.0 -> 1.7.1`                                                    |
| [`3024611e`](https://github.com/NixOS/nixpkgs/commit/3024611e45c99bb500dc2b7756cc47aeb213cbae) | `maintainers: add florentc`                                                  |
| [`398168af`](https://github.com/NixOS/nixpkgs/commit/398168af5297d9b36ebd83ce9fc78ec3b5161fc1) | `platformio: override zeroconf`                                              |
| [`ee718148`](https://github.com/NixOS/nixpkgs/commit/ee718148c8d8e115e7143ee0dec94301358e1577) | `audacious: 4.0.5 -> 4.1`                                                    |
| [`81e2e672`](https://github.com/NixOS/nixpkgs/commit/81e2e672a45cbc7ead60aaba23d01b684d89f84f) | `python3Packages.zeroconf: 0.36.13 -> 0.37.0`                                |
| [`7c4bbc7c`](https://github.com/NixOS/nixpkgs/commit/7c4bbc7cd008fb3802e3b5ea44118ebfc013578d) | `Updating F3D URLs for F3D migration (#147173)`                              |
| [`c591aba8`](https://github.com/NixOS/nixpkgs/commit/c591aba83f758235d1948a890659f32cbbf08544) | `python3Packages.awesomeversion: 21.10.1 -> 21.11.0`                         |
| [`4ae4e9e2`](https://github.com/NixOS/nixpkgs/commit/4ae4e9e28c0e620a7d01fbddc38cb85fe7f81449) | `python3Packages.keyring: 23.2.1 -> 23.3.0`                                  |
| [`3c5996d1`](https://github.com/NixOS/nixpkgs/commit/3c5996d1e6cebd3d15d0639994cce177459747a7) | `jenkins: 2.303.1 -> 2.303.3`                                                |
| [`24b606e9`](https://github.com/NixOS/nixpkgs/commit/24b606e95a40544cfabdb9fb44409b42a3b08d90) | `solaar: 1.0.6 -> 1.0.7`                                                     |
| [`7402bc6c`](https://github.com/NixOS/nixpkgs/commit/7402bc6c2e12081e81ccb68ed32d638c5b62710d) | `yfinance: fix build`                                                        |
| [`6dc23393`](https://github.com/NixOS/nixpkgs/commit/6dc23393d9a24abfff423a2ea4bfc574cebd4eca) | `glymur: fix build`                                                          |
| [`5a61f081`](https://github.com/NixOS/nixpkgs/commit/5a61f08144fcc7386ca0980dc3b37861c7937e63) | `pantheon.elementary-code: 6.0.1 -> 6.1.0`                                   |
| [`f8fddafe`](https://github.com/NixOS/nixpkgs/commit/f8fddafe3c8a48dc55a35e0693c61b243eb8a36a) | `heisenbridge: add patch for compatibility with aiohttp 3.8.0`               |
| [`bb0f6ad8`](https://github.com/NixOS/nixpkgs/commit/bb0f6ad8d25fee7a9fe76d29b0d1e03ce84cf6da) | `lnd: 0.14.0-beta -> 0.14.1-beta`                                            |
| [`ad8a2e81`](https://github.com/NixOS/nixpkgs/commit/ad8a2e81dab365e759c47588bfd80658709fb3be) | `python3Packages.asyncmy: init at 0.2.3`                                     |
| [`f1c16183`](https://github.com/NixOS/nixpkgs/commit/f1c16183c8c7c78a3f372251e9af0f465d0bb355) | `buildGraalvmNativeImage: fix meta, add --verbose flag`                      |
| [`e9766a85`](https://github.com/NixOS/nixpkgs/commit/e9766a85bdf15c525bdcb5b16040608ff7b9233f) | `zprint: use buildGraalvmNativeImage`                                        |
| [`d352856e`](https://github.com/NixOS/nixpkgs/commit/d352856ea2148e4ec1de2b5769dfcf79c1356d99) | `buildGraalvmNativeImage: default executable to pname`                       |
| [`3100248d`](https://github.com/NixOS/nixpkgs/commit/3100248dbb4b47c5b4f9fbc836feab46bed87e37) | `jet: use buildGraalvmNativeImage`                                           |
| [`a277e9d4`](https://github.com/NixOS/nixpkgs/commit/a277e9d457925d917f1288d3cef16665d423320e) | `clj-kondo: use buildGraalvmNativeImage`                                     |
| [`7c632551`](https://github.com/NixOS/nixpkgs/commit/7c632551c1f5e6430779f03e45ce0d0296e54442) | `clojure-lsp: use buildGraalvmNativeImage`                                   |
| [`052fb6a2`](https://github.com/NixOS/nixpkgs/commit/052fb6a228ea1c573aec957b95a804ba70e41527) | `babashka: use buildGraalvmNativeImage`                                      |
| [`1415e308`](https://github.com/NixOS/nixpkgs/commit/1415e30830e9fae776cbd08a4934a4cdc66e1a02) | `buildGraalvmNativeImage: init`                                              |
| [`9e58e392`](https://github.com/NixOS/nixpkgs/commit/9e58e392a463a5e0c6585e179746b20f138054f7) | `mindustry: format mindustry in top-level/all-packages nicely`               |
| [`4179df35`](https://github.com/NixOS/nixpkgs/commit/4179df352ba3d2dabf7039b795bebf5068283c28) | `mindustry: fix eval error due to #119444`                                   |
| [`a77943c9`](https://github.com/NixOS/nixpkgs/commit/a77943c99ae0a2c6cc465d084aec0ca269ba5b91) | `mindustry-server: use jdk15 to build server`                                |
| [`7824302d`](https://github.com/NixOS/nixpkgs/commit/7824302dd034e7e08088f5dda982aacde63aa3b4) | `mindustry: mitigate issue with missing glew`                                |
| [`19c06baf`](https://github.com/NixOS/nixpkgs/commit/19c06baf6c4bde49fbfb592d64ccac6ca69950d7) | `mindustry: unbreak by building with jdk15`                                  |
| [`407307dd`](https://github.com/NixOS/nixpkgs/commit/407307ddf83c0bfdd82ace48c26ac2df03523228) | `kdeltachat: unstable-2021-10-27 -> unstable-2021-11-14`                     |
| [`f7741e23`](https://github.com/NixOS/nixpkgs/commit/f7741e234d82b647b85fe053dcb5883de47ffe90) | `libdeltachat: 1.65.0 -> 1.66.0`                                             |
| [`4deec4ec`](https://github.com/NixOS/nixpkgs/commit/4deec4ec53da8ba6cfd7b1cd2e0155ae233bb150) | `kratos: 0.7.6-alpha.1 -> 0.8.0-alpha.3`                                     |
| [`0e8e7c81`](https://github.com/NixOS/nixpkgs/commit/0e8e7c819c7d47b4b3dacda8ecedb81d3df6c8ab) | `libretro.blastem: init at unstable-2021-11-22`                              |
| [`82b4887f`](https://github.com/NixOS/nixpkgs/commit/82b4887f1eab1563e9e0dd2a28a9ba7a60f317e2) | `libretro: unstable-2021-11-16 -> unstable-2021-11-22`                       |
| [`9aee0414`](https://github.com/NixOS/nixpkgs/commit/9aee0414e031b7f80165926acdebe22fb4da6b60) | `libretro.bsnes-hd: init at unstable-2021-11-22`                             |
| [`2fe38278`](https://github.com/NixOS/nixpkgs/commit/2fe3827806ff9e4b9878ee01c891565aea38bf35) | `libretro.bsnes: init at unstable-2021-11-22`                                |
| [`d204860b`](https://github.com/NixOS/nixpkgs/commit/d204860bf5e8efd81b6c7f1328a5ee633fb04cf0) | `libretro.mesen-s: init at unstable-2021-11-22`                              |
| [`cda90888`](https://github.com/NixOS/nixpkgs/commit/cda90888f2ac1bdfefdf72141f993ca4449d5326) | `heisenbridge: 1.7.0 -> 1.7.1`                                               |
| [`d03b66c4`](https://github.com/NixOS/nixpkgs/commit/d03b66c4a61fde97ef4d6519fca9471fbd79c610) | `libretro.mesen: switch to libretro/mesen`                                   |
| [`18bc6a9e`](https://github.com/NixOS/nixpkgs/commit/18bc6a9efe31b29306b198122e82e0022a4f90b1) | `libretro.melonds: init at unstable-2021-11-22`                              |
| [`0d9f8458`](https://github.com/NixOS/nixpkgs/commit/0d9f8458a604cb6b94d702e70c941c9bd7c67420) | `retroarch: switch from libretro-super to libretro-core-info`                |
| [`716deb5a`](https://github.com/NixOS/nixpkgs/commit/716deb5afb75d3641250a8643053838b25f737d0) | `libretro.beetle-saturn-hw: remove`                                          |
| [`17c37fe0`](https://github.com/NixOS/nixpkgs/commit/17c37fe0bd91a36b447560585181924336056c0c) | `libretro.bsnes-mercury-{balanced,performance}: init at unstable-2021-11-16` |
| [`702c8f29`](https://github.com/NixOS/nixpkgs/commit/702c8f29fbca2a492864e00436457ba3b41392e3) | `libretro: expose mkLibeRetroCore function`                                  |
| [`99471988`](https://github.com/NixOS/nixpkgs/commit/994719881acfc2633ea2a66ea2149e89065ed126) | `libretro.swanstation: init at unstable-2021-11-21`                          |
| [`33478a11`](https://github.com/NixOS/nixpkgs/commit/33478a118c33e450881fa405362bb58b729cf78c) | `libretro: make update.py script accept individual cores to update`          |
| [`70e4672c`](https://github.com/NixOS/nixpkgs/commit/70e4672c91226d8a93750e09f0697b5fb60d7b64) | `graphene: support cross-compilation`                                        |
| [`ff8a5ba7`](https://github.com/NixOS/nixpkgs/commit/ff8a5ba767e9819e79ca97150d585ebf58369f2c) | `libnice: support cross-compilation`                                         |
| [`4f8a79c4`](https://github.com/NixOS/nixpkgs/commit/4f8a79c4fe9466a9814ce2edc9db623ada55e518) | `gupnp-igd: fix cross-compilation`                                           |
| [`856ca0f5`](https://github.com/NixOS/nixpkgs/commit/856ca0f52f704d99aebb3aacd58bfbcce6e31750) | `gupnp: fix cross-compilation`                                               |
| [`b827b46c`](https://github.com/NixOS/nixpkgs/commit/b827b46c8d17a57999b371e49bbd24812e3324df) | `gssdp: fix cross-compilation`                                               |
| [`7d310da8`](https://github.com/NixOS/nixpkgs/commit/7d310da826fa2cf9d034bf40ee1f73694fa2ef56) | `swayr: 0.7.0 -> 0.10.0`                                                     |
| [`2b7ab562`](https://github.com/NixOS/nixpkgs/commit/2b7ab562eac330d451942fb11010a55a9190b811) | `matrix-appservice-irc: remove piegames as maintainer`                       |
| [`be0c385a`](https://github.com/NixOS/nixpkgs/commit/be0c385a5dbff42eece4b9efec028932cf1b3bc7) | `matrix-appservice-irc: improve update script`                               |