### PR TITLE
chore(flake/nixpkgs): `07e3b292` -> `27abb57b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637871473,
-        "narHash": "sha256-Qn5/H/m8F0zTWUOMcywH5DQLD3HPCJj/OHz+7f5EMqc=",
+        "lastModified": 1637914536,
+        "narHash": "sha256-tIFRbGtRy3ODL0SBW7HRAIehBGJN6TVitPllADL5mGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "07e3b29217491dcee2c8e71d8da764342cd414d7",
+        "rev": "27abb57b7fff5c4164de6ec3dd6840177e83a11e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`92c01996`](https://github.com/NixOS/nixpkgs/commit/92c0199687e1838710571020bf7f6957dc7629e1) | `iterm2: 3.4.0 -> 3.4.13`                                            |
| [`9949f100`](https://github.com/NixOS/nixpkgs/commit/9949f1009d9ce7c58d94cf69b4de3bd58087cf98) | `pantheon.switchboard-plug-onlineaccounts: 6.2.1 -> 6.2.2`           |
| [`129a6094`](https://github.com/NixOS/nixpkgs/commit/129a60944321ce8754e3d191f7641aae4e237896) | `python3Packages.tensorflow: remove aliases with _2 suffix`          |
| [`133406d0`](https://github.com/NixOS/nixpkgs/commit/133406d085953796f11b84622f87a949b56730a9) | `exploitdb: 2021-11-24 -> 2021-11-25`                                |
| [`8c00ef66`](https://github.com/NixOS/nixpkgs/commit/8c00ef66595e9f434961f96673fe414f8631563f) | `python3Packages.python-izone: add patch to support async_timeout>4` |
| [`c9a4c5e0`](https://github.com/NixOS/nixpkgs/commit/c9a4c5e03289d4221933b51cd05a847845829bdc) | `nux: init at 0.1.4`                                                 |
| [`8f135db3`](https://github.com/NixOS/nixpkgs/commit/8f135db3d4c2c9c0d37df34160a11e373ee250ad) | `maintainers: add drzoidberg`                                        |
| [`4ea35c4c`](https://github.com/NixOS/nixpkgs/commit/4ea35c4c20eb905b775baae4590b8132ee19f2f2) | `delta: 0.10.0 -> 0.10.1`                                            |
| [`01b6b94b`](https://github.com/NixOS/nixpkgs/commit/01b6b94bb997da04ea2706af7ad3270a8c782da0) | `python3Packages.luftdaten: 0.7.0 -> 0.7.1`                          |
| [`5cb1d651`](https://github.com/NixOS/nixpkgs/commit/5cb1d65110f1c3a8222279227ef64650c75396b6) | `python3Packages.luftdaten: 0.6.5 -> 0.7.0`                          |
| [`17964e23`](https://github.com/NixOS/nixpkgs/commit/17964e23129a184caa42c1476eab20e3b5ed19ec) | `bunyan-rs: 0.1.2 -> 0.1.6`                                          |
| [`928afefa`](https://github.com/NixOS/nixpkgs/commit/928afefaf3686fd862078bc64c480ddd8bd44fb6) | `python3Packages.requests-cache: disable flaky tests`                |
| [`0d808eea`](https://github.com/NixOS/nixpkgs/commit/0d808eea61eacd7651053a5b3b42f6e40eee47b6) | `python3Packages.hatasmota: 0.2.21 -> 0.3.0`                         |
| [`a8d7fda0`](https://github.com/NixOS/nixpkgs/commit/a8d7fda016651bf23e73fdf816999a06f1f64a74) | `python3Packages.pycocotools: 2.0.2 -> 2.0.3`                        |
| [`a952e557`](https://github.com/NixOS/nixpkgs/commit/a952e5579bb00bdccdf7d2666fc04f1c5019deda) | `python3Packages.pythonegardia: add patch for search path`           |
| [`7d590539`](https://github.com/NixOS/nixpkgs/commit/7d5905395da0dba83349dae80225b30c83b1aee1) | `geoclue2: add geoclue2-with-demo-agent to be cached`                |
| [`b47648f6`](https://github.com/NixOS/nixpkgs/commit/b47648f6c820e9d814f4633d3acaea07019652df) | `mariadb-connector-c: fix static build (#147166)`                    |
| [`e822c34f`](https://github.com/NixOS/nixpkgs/commit/e822c34ff96092aafa25c85ad745b62b1766f3e8) | `python3Packages.seaborn: add missing dependencies`                  |
| [`1461ac6e`](https://github.com/NixOS/nixpkgs/commit/1461ac6eddced5535980c0b591778a7620715b55) | `python3Packages.zigpy-znp: 0.5.4 -> 0.6.1`                          |
| [`1d2c379e`](https://github.com/NixOS/nixpkgs/commit/1d2c379e3b8a172dfa8688f2065da062c01bb766) | `graphviz_2_32: remove`                                              |
| [`86b26618`](https://github.com/NixOS/nixpkgs/commit/86b2661837d41d6733bdf42e9e5e1414b17bf624) | `guitone: remove package`                                            |
| [`0ab64335`](https://github.com/NixOS/nixpkgs/commit/0ab64335ae9b00c9ac20359ada9c366765e7e060) | `python3Packages.zigpy: 0.39.0 -> 0.41.0`                            |
| [`c1790982`](https://github.com/NixOS/nixpkgs/commit/c1790982b33c54b21ce7b6efe5600063db50930b) | `python3Packages.zwave-js-server-python: 0.31.3 -> 0.33.0`           |
| [`829b8d22`](https://github.com/NixOS/nixpkgs/commit/829b8d2228ddfc424931abf406218e3af184be33) | `python3Packages.mypy-boto3-s3: 1.20.1 -> 1.20.12`                   |
| [`4f5daac9`](https://github.com/NixOS/nixpkgs/commit/4f5daac94e7e990bb753198ed48157d2f4054a8e) | `factor-lang: Rewrite builder in preparation for 0.99`               |
| [`60fd1074`](https://github.com/NixOS/nixpkgs/commit/60fd1074df99476b9d26450cea601e25b2cd36e7) | `python3Packages.pysmartthings: 0.7.6 -> 0.7.7`                      |
| [`1432f5c3`](https://github.com/NixOS/nixpkgs/commit/1432f5c30d27c1dfaaa29332d00f7f2a8e64fef4) | `godns: 2.5.1 -> 2.5.2`                                              |
| [`547190bd`](https://github.com/NixOS/nixpkgs/commit/547190bdac4b3864422032a644fc97e8bcc6fdd8) | `python3Packages.PyChromecast: 9.3.1 -> 10.1.1`                      |
| [`0701680d`](https://github.com/NixOS/nixpkgs/commit/0701680d0c8d5f8375123a16105e32359b829dcb) | `python3Packages.tensorflow-bin: 2.4.0 -> 2.7.0`                     |
| [`148be0ec`](https://github.com/NixOS/nixpkgs/commit/148be0ecca6590be88e7a21c081f96287a2d4a28) | `python3Packages.tensorflow: 2.4.2 -> 2.7.0`                         |
| [`49c2a693`](https://github.com/NixOS/nixpkgs/commit/49c2a6930dcaf890cfa95648acfdfc1fa06cd323) | `python3Packages.tensorflow-estimator: 2.4.0 -> 2.7.0`               |
| [`d2f48288`](https://github.com/NixOS/nixpkgs/commit/d2f48288716a257fdc122bcef98a1b97e591ee41) | `trilium: 0.48.6 -> 0.48.7`                                          |
| [`dd78a081`](https://github.com/NixOS/nixpkgs/commit/dd78a081d93f3fc161b7722f95da67cbe80e8cd5) | `python3Packages.plugwise: 0.14.5 -> 0.15.2`                         |
| [`e248ab37`](https://github.com/NixOS/nixpkgs/commit/e248ab379af438d3b972b8a8b7c3f73b6239978e) | `picoscope: set LANG=C in wrapper`                                   |
| [`d5607393`](https://github.com/NixOS/nixpkgs/commit/d56073935dc006bdaa756f424b2b32fe19bccc64) | `picoscope: 7.0.83 -> 7.0.86`                                        |
| [`19655f34`](https://github.com/NixOS/nixpkgs/commit/19655f343be6cdc78df4c74c0fcf599acfd3331b) | `python3Packages.aiohomekit: 0.6.3 -> 0.6.4`                         |
| [`16786190`](https://github.com/NixOS/nixpkgs/commit/16786190a43fdcd6a5fe48f3bb9e6f3af6ab70cd) | `python3Packages.simplisafe-python: 2021.11.0 -> 2021.11.2`          |
| [`77142ce9`](https://github.com/NixOS/nixpkgs/commit/77142ce97b52c44e0044ad56f32f815e26ac95a7) | `python3Packages.simplisafe-python: 2021.10.0 -> 2021.11.0`          |
| [`5565ac12`](https://github.com/NixOS/nixpkgs/commit/5565ac12ac91be1c7f453ef1913f1d358b52ceea) | `python3Packages.pysma: 0.6.8 -> 0.6.9`                              |
| [`5584d824`](https://github.com/NixOS/nixpkgs/commit/5584d8246fbedffd75016740a41a6bad9c8a4e59) | `python3Packages.screenlogicpy: 0.4.3 -> 0.5.0`                      |
| [`81927aaf`](https://github.com/NixOS/nixpkgs/commit/81927aaf236c1158e400d561e8fb54e99dddee1f) | `python3Packages.airthings-cloud: 0.0.1 -> 0.1.0`                    |