### PR TITLE
chore(flake/nixpkgs): `16eb0035` -> `3e610e1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638045166,
-        "narHash": "sha256-HguPozGbLldZ9BBQbD02S+LkgLkB2szsAyCf22Wx0Cs=",
+        "lastModified": 1638090002,
+        "narHash": "sha256-mLo7PJK/Gmk+oZp+N0hg63shpPxXsV5W5jvindChjGs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16eb003524804f7c6d6f522a238e8ab2557eedf9",
+        "rev": "3e610e1d39a0b06ebb0eab6265bc4317a1eae38c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`b3572654`](https://github.com/NixOS/nixpkgs/commit/b35726542e8cf68512e87fbd23eb22778f977f22) | `docbookrx: fix build`                                                                        |
| [`8d4f2c38`](https://github.com/NixOS/nixpkgs/commit/8d4f2c38168d8822584c255a4cccb5946aa85205) | `streamlink: 3.0.1 -> 3.0.3`                                                                  |
| [`1561c366`](https://github.com/NixOS/nixpkgs/commit/1561c366ab92246fc7f4e2e6b48b394e944c8703) | `libAfterImage: fix binutils-2.36 compatibility (#147617)`                                    |
| [`f07f124d`](https://github.com/NixOS/nixpkgs/commit/f07f124d3a1bf6e441a899410b65aa1b09902905) | `jing-trang: 20151127 -> 20181222`                                                            |
| [`ade2d34d`](https://github.com/NixOS/nixpkgs/commit/ade2d34d4f965abd6acfa54dc10ee00a057a703b) | `pdns-recursor: 4.5.6 -> 4.5.7`                                                               |
| [`4a48b34e`](https://github.com/NixOS/nixpkgs/commit/4a48b34ead2b9ecde64fb3d3421cc78f4a601793) | `python3Packages.jupyterhub-systemdspawner: install check-kernel.bash`                        |
| [`58f88a56`](https://github.com/NixOS/nixpkgs/commit/58f88a56c26ecb405d4332b0f0bc5ea96363b639) | `anytype: 0.21.1 -> 0.21.9`                                                                   |
| [`8fb36866`](https://github.com/NixOS/nixpkgs/commit/8fb36866b8be4ebad0c160845774008a1d3f851d) | `octopus: 11.2 -> 11.3`                                                                       |
| [`909df3fa`](https://github.com/NixOS/nixpkgs/commit/909df3fa25f094fbf81b4780e018e7bf86f201e0) | `delta: 0.10.1 -> 0.10.2`                                                                     |
| [`9440449a`](https://github.com/NixOS/nixpkgs/commit/9440449acbf32742850395c22345efe2e69ee322) | `aaphoto: set meta.broken to true in Darwin`                                                  |
| [`fc66ea69`](https://github.com/NixOS/nixpkgs/commit/fc66ea690a8eb88734af58cd1c533935dc9ec4f4) | `aaphoto: init at 0.43.1`                                                                     |
| [`66236eeb`](https://github.com/NixOS/nixpkgs/commit/66236eeb4bb0c8ef1b61e4ffe2d829acbbd2ffaf) | `flam3: 3.1.1 -> 3.1.1+date=2018-04-12`                                                       |
| [`f622890f`](https://github.com/NixOS/nixpkgs/commit/f622890f9b8b1fd0b00e7381171c39ee882cfa6d) | `xonsh: 0.10.1 -> 0.11.0`                                                                     |
| [`609ab2cd`](https://github.com/NixOS/nixpkgs/commit/609ab2cdc478bf1147cf90ba49b2c20108342139) | `btop: 1.1.0 -> 1.1.2`                                                                        |
| [`de31473c`](https://github.com/NixOS/nixpkgs/commit/de31473c422e4ae7d2386319ba3e1d3039546d48) | `losslessaudiochecker: init at 2.0.5`                                                         |
| [`c249f14b`](https://github.com/NixOS/nixpkgs/commit/c249f14bf8249246eacf342225996903acf5e1ef) | `wireshark: add wrapGAppsHook fixing open/save GUI`                                           |
| [`84730c9f`](https://github.com/NixOS/nixpkgs/commit/84730c9f5de7a14ff0a951541e4ec84233df393b) | `janus-gateway: fix build`                                                                    |
| [`836866f9`](https://github.com/NixOS/nixpkgs/commit/836866f9f4b70fdfb56177b9eae01e8746b07bff) | `flexget: 3.1.153 -> 3.2.1`                                                                   |
| [`abcbdc61`](https://github.com/NixOS/nixpkgs/commit/abcbdc61e4c1e8f418d9225708fdd7beb9ad2343) | `gallery-dl: 1.19.2 -> 1.19.3`                                                                |
| [`479cf400`](https://github.com/NixOS/nixpkgs/commit/479cf4005bed53098cf41bcee840e33fd06538b1) | `nodePackages.gramma: init at 1.6.0`                                                          |
| [`9327db35`](https://github.com/NixOS/nixpkgs/commit/9327db355462f78f7c85fe8d40851ebea8266c2f) | `python3Packages.tensorflowWithCuda: upgrade cuda to recommended 11.2 to fix runtime warning` |
| [`f5798c8f`](https://github.com/NixOS/nixpkgs/commit/f5798c8f3d07cee4d192e9e5fe68ed75e59fc983) | `python3Packages.tensorflowWithCuda: fix patchelf failures`                                   |
| [`449c0a1d`](https://github.com/NixOS/nixpkgs/commit/449c0a1d22f29cc8f512bbac4422d11d48fbe37c) | `patchelfUnstable: 2020-07-11 -> 2021-11-16`                                                  |
| [`670599a0`](https://github.com/NixOS/nixpkgs/commit/670599a05aa7e3a339d0920623dfa3dab8e77f42) | `home-assistant: relax dependencies`                                                          |
| [`6da3d9a7`](https://github.com/NixOS/nixpkgs/commit/6da3d9a7494f4df82891dd2fc82e8ebe5acd2518) | `prometheus-node-exporter: 1.2.2 -> 1.3.0`                                                    |
| [`01a19ba4`](https://github.com/NixOS/nixpkgs/commit/01a19ba42f8d71545369328ece06899e8dfc7a34) | `materialize: 0.9.4 -> 0.10.0`                                                                |
| [`21585dc6`](https://github.com/NixOS/nixpkgs/commit/21585dc6836ce68fe181a90f9eff5d77fb79fc3f) | `nixos/vmware-guest: add display-manager to after and`                                        |
| [`a34736a3`](https://github.com/NixOS/nixpkgs/commit/a34736a38fb86a5b1ff1139c0885a629d232e419) | `geogebra6 6-0-644-0 -> 6-0-676-0`                                                            |
| [`33006357`](https://github.com/NixOS/nixpkgs/commit/33006357d1806f10b538e669316da90e60fe4fd5) | `cpplint: 1.5.1 -> 1.5.5`                                                                     |
| [`0935cb7e`](https://github.com/NixOS/nixpkgs/commit/0935cb7ed72fd6ec5df0e790363b3ff6a0123da1) | `httping: pull upstream fix for ncurses-6.3`                                                  |
| [`b3b25bf6`](https://github.com/NixOS/nixpkgs/commit/b3b25bf6020c9bf2d48c91070228e707264d6ffb) | `gitignore: add outputs/ and source/`                                                         |