### PR TITLE
chore(flake/nixpkgs): `3e610e1d` -> `fb41277d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638090002,
-        "narHash": "sha256-mLo7PJK/Gmk+oZp+N0hg63shpPxXsV5W5jvindChjGs=",
+        "lastModified": 1638133678,
+        "narHash": "sha256-iYpfV+O1RwFZvDBpWgNDO5JfSOTCe456j457L22JYs0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e610e1d39a0b06ebb0eab6265bc4317a1eae38c",
+        "rev": "fb41277df396a390a08a3b3afa57f122df618d4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`37af67a8`](https://github.com/NixOS/nixpkgs/commit/37af67a84a6210c65ce7e61efcad9bf96e3dbc50) | `rdma-core: 37.1 -> 38.0`                                                 |
| [`5c589d83`](https://github.com/NixOS/nixpkgs/commit/5c589d83edadc493b0c99a663f1433cf9c8f2b80) | `libretro: fix core platforms`                                            |
| [`7ff536ed`](https://github.com/NixOS/nixpkgs/commit/7ff536edd6a8fff222889229dce7d2673f0ab463) | `libretro: remove "-DCMAKE_BUILD_TYPE=Release"`                           |
| [`6f05bc37`](https://github.com/NixOS/nixpkgs/commit/6f05bc3791cd7d27cdc376548df4ce05d9a4ce6d) | `libretro.pcsx2: init at unstable-2021-11-27`                             |
| [`f6053b7c`](https://github.com/NixOS/nixpkgs/commit/f6053b7c826d4927e1d9460027b15281b8211d79) | `verifpal: 0.26.0 -> 0.26.1 (#143282)`                                    |
| [`079827e8`](https://github.com/NixOS/nixpkgs/commit/079827e8c3cc5f0c1624edc105d17da258ae5f0d) | `todoist: 0.15.0 -> 0.16.0`                                               |
| [`8f1a52ac`](https://github.com/NixOS/nixpkgs/commit/8f1a52ac33fb9a441713261c35cecab7b5331512) | `haskell.compiler.*: disable useLLVM also for SPARC and PowerPC`          |
| [`5a76214c`](https://github.com/NixOS/nixpkgs/commit/5a76214c5d2277a28fe15a18f3e95cf89fcd03e8) | `ocamlPackages.reactivedata: fix src hash`                                |
| [`a59add84`](https://github.com/NixOS/nixpkgs/commit/a59add846d7785ec13622c7856bc5e4f0d521866) | `python3Packages.crownstone-sse: 2.0.2 -> 2.0.3`                          |
| [`9991cd36`](https://github.com/NixOS/nixpkgs/commit/9991cd362517e23115796c124fbefe9f09f9ecbf) | `python3Packages.flux-led: 0.25.0 -> 0.25.1`                              |
| [`c80cb3ca`](https://github.com/NixOS/nixpkgs/commit/c80cb3ca818a47cdedbf0b75c8b5b6d9b9ff03a7) | `lispPackages: add cl-shellwords`                                         |
| [`b1494f81`](https://github.com/NixOS/nixpkgs/commit/b1494f8182aa635a909fec930a3dc8c700ea89c9) | `cherrytree: 0.99.42 -> 0.99.43`                                          |
| [`3076b3d0`](https://github.com/NixOS/nixpkgs/commit/3076b3d087344ce250ec3f3ae0c554416357dd01) | `hashcat: 6.2.4 -> 6.2.5`                                                 |
| [`5cfe3c4e`](https://github.com/NixOS/nixpkgs/commit/5cfe3c4e82118dd732ffb23c469b128ed8ee3283) | `gromacs: fix double precission build on aarch64`                         |
| [`c0966f85`](https://github.com/NixOS/nixpkgs/commit/c0966f8571c17fceb93aef059ddbf321e5b0fefd) | `pantheon.elementary-code: remove zeitgeist from buildInputs`             |
| [`b1005e8b`](https://github.com/NixOS/nixpkgs/commit/b1005e8b3d0fa1b95fc624b078b5db65b22ff0c9) | `pantheon.switchboard: remove clutter-gtk from buildInputs`               |
| [`840af81e`](https://github.com/NixOS/nixpkgs/commit/840af81e55f4936be6cc3b58c7010ca1cd164745) | `storm: 2.2.0 -> 2.3.0`                                                   |
| [`8b88a195`](https://github.com/NixOS/nixpkgs/commit/8b88a195712f2a861e58cc8ccd9119d231b60bbd) | `getdata: 0.10.0 -> 0.11.0`                                               |
| [`9a005535`](https://github.com/NixOS/nixpkgs/commit/9a005535faf25b19c46689f1d14111e1750d9fab) | `hwinfo: 21.76 -> 21.78`                                                  |
| [`27e1ecfd`](https://github.com/NixOS/nixpkgs/commit/27e1ecfde52607e9f4968d36bee22ac5a77427ed) | `cpufetch: 1.00 -> 1.01`                                                  |
| [`97a3b2af`](https://github.com/NixOS/nixpkgs/commit/97a3b2af1dc0a781f6a5886b536628d374c65c4b) | `monero: rename to monero-cli`                                            |
| [`9d80a436`](https://github.com/NixOS/nixpkgs/commit/9d80a43612af5e1a50bfab734aac0e5a88ad8e60) | `julia_16-bin: 1.6.3 -> 1.6.4`                                            |
| [`0050284d`](https://github.com/NixOS/nixpkgs/commit/0050284daabd584054773f3a23f8b6254264e998) | `mbuffer: 20210328 -> 20211018`                                           |
| [`8874d307`](https://github.com/NixOS/nixpkgs/commit/8874d30775f0b1a5c6d58423f2ec36d20154c58f) | `dero: remove package (#147656)`                                          |
| [`a537690d`](https://github.com/NixOS/nixpkgs/commit/a537690d30d5ace874fe9838c12ec82f28fc4473) | `Revert "wireshark: add wrapGAppsHook fixing open/save GUI"`              |
| [`17c11a63`](https://github.com/NixOS/nixpkgs/commit/17c11a63a79c35bce93a7e263c05d14c8f460194) | `mkvtoolnix: 62.0.0 -> 63.0.0`                                            |
| [`51694b0a`](https://github.com/NixOS/nixpkgs/commit/51694b0af4e811dabac490b98eba588b06585cdd) | `root5: binutils 2.37 fix`                                                |
| [`182c8be4`](https://github.com/NixOS/nixpkgs/commit/182c8be43317221676de695fa76dd680e4bc7ee9) | `slicer: fix build`                                                       |
| [`95312f56`](https://github.com/NixOS/nixpkgs/commit/95312f56b5846503c5629b87df413f386b46a2ef) | `umap-learn: fix build`                                                   |
| [`c192da17`](https://github.com/NixOS/nixpkgs/commit/c192da17cc4d87460664d72c1a845647d4b6e46b) | `nixUnstable: 2.5pre20211007 -> 2.5pre20211126`                           |
| [`b930e3fe`](https://github.com/NixOS/nixpkgs/commit/b930e3fe52657cb58ebbf4fcb91030151fbd4f14) | `btrfs-snap: init at 1.7.3`                                               |
| [`0fff6b89`](https://github.com/NixOS/nixpkgs/commit/0fff6b89eac2a9bcf743dfaca7f0ee956a683be5) | `hydrus: 462 -> 463`                                                      |
| [`40fb87f5`](https://github.com/NixOS/nixpkgs/commit/40fb87f5ca84fb7d5299041a9aa632410108f6e7) | `nixos/doc: Add note about big updates regarding hydrus to release notes` |
| [`ef62ecac`](https://github.com/NixOS/nixpkgs/commit/ef62ecac5f9d21990a97ed96e5f909e8efce60f8) | `mame: 0.237 -> 0.238`                                                    |
| [`a84f06bb`](https://github.com/NixOS/nixpkgs/commit/a84f06bba158e141dbf9207ce3da32e6171522d2) | `python3Packages.flux-led: 0.24.25 -> 0.25.0`                             |
| [`a697c03e`](https://github.com/NixOS/nixpkgs/commit/a697c03e850600b95ba4a2518a9c609069a82974) | `cudatext: 1.148.0 → 1.150.0`                                             |
| [`b6d26384`](https://github.com/NixOS/nixpkgs/commit/b6d263844900415858e796382b473e3633cb9eaa) | `appgate-sdp: 5.4.2 -> 5.5.0`                                             |
| [`a38fd4fa`](https://github.com/NixOS/nixpkgs/commit/a38fd4faef054319c5903601e6a4e5f0032236b3) | `exploitdb: 2021-11-25 -> 2021-11-27`                                     |
| [`33c8bc71`](https://github.com/NixOS/nixpkgs/commit/33c8bc71868a04e0ce91ab5f7bbba85f8fef9bae) | `polylith: 0.2.12-alpha -> 0.2.13-alpha`                                  |
| [`17b8b5a4`](https://github.com/NixOS/nixpkgs/commit/17b8b5a4dc5a49d83d508cb66c6ac2f0bb9fa39b) | `haskell.compiler.*: pass runtime dependencies via configure script`      |
| [`006f1f79`](https://github.com/NixOS/nixpkgs/commit/006f1f795d4c612ebe7db7f11d1c92f9467e0b8d) | `sudo-font: 0.60 -> 0.61`                                                 |
| [`14e055c4`](https://github.com/NixOS/nixpkgs/commit/14e055c454689084a352f9a5b07f2e41f23541e7) | `wtf: 0.39.2 -> 0.40.0`                                                   |
| [`ab8482e1`](https://github.com/NixOS/nixpkgs/commit/ab8482e19356669c5b989a2241cacbb3fb797792) | `fstar: 2021.10.16 -> 2021.11.27`                                         |
| [`92cc9524`](https://github.com/NixOS/nixpkgs/commit/92cc9524c0f0255d660fd2b4f6f982a6192a8b55) | `recursive: 1.082 -> 1.084`                                               |
| [`32f21eef`](https://github.com/NixOS/nixpkgs/commit/32f21eefab39537224743b664a03800d0c566ba7) | `git-review: 2.1.0 → 2.2.0`                                               |
| [`f567ff44`](https://github.com/NixOS/nixpkgs/commit/f567ff4440b5cfe085348620c2784d71cc5c7792) | `pulseaudio-dlna: ensure pactl is available`                              |
| [`b1204359`](https://github.com/NixOS/nixpkgs/commit/b1204359faf82a68465ba285f8d40dffd671241e) | `pulseaudio-dlna: minor cleanups`                                         |
| [`558da925`](https://github.com/NixOS/nixpkgs/commit/558da925f33e1b4cb9469997175bf9bdd56586b0) | `ghc: make sure top level exposed GHC is always host->target`             |
| [`ef081bf3`](https://github.com/NixOS/nixpkgs/commit/ef081bf3056f3facd2a0b85b172c5c730a0404e8) | `haskell.compiler.*: don't useLLVM if aarch64-darwin NCG is available`    |
| [`50f256f5`](https://github.com/NixOS/nixpkgs/commit/50f256f5efb8ec79a76c5de0c4d37d84643a98e8) | `ghcWithPackages: don't wrap GHC with LLVM unnecessarily`                 |
| [`cede244a`](https://github.com/NixOS/nixpkgs/commit/cede244af9bbda364b2f27892984d78923d5a6ed) | `php80Extensions.xmlreader: fix build`                                    |
| [`6dfffc7d`](https://github.com/NixOS/nixpkgs/commit/6dfffc7d4918560eb3015a6e90e8e1b7959f16bf) | `php80: 8.0.12 -> 8.0.13`                                                 |
| [`183cc6ea`](https://github.com/NixOS/nixpkgs/commit/183cc6ea800548e6b62bd1f972caee25813b3904) | `php74: 7.4.25 -> 7.4.26`                                                 |
| [`a7c56459`](https://github.com/NixOS/nixpkgs/commit/a7c564596e195cf9aa46ad2762f78e4d9cc9789b) | `haskell.compiler.*: use `isScript` over grepping for `#!``               |
| [`f5c3b652`](https://github.com/NixOS/nixpkgs/commit/f5c3b6523cab9861a343b1f49081205d799695c6) | `haskell.compiler.*: move propagatedBuildInputs into runtimeDeps`         |
| [`035f20bc`](https://github.com/NixOS/nixpkgs/commit/035f20bc6bf809c7be9bb5b6d4dd19b0a2df9d17) | `haskell.compiler.*: prefix PATH with runtimeDeps`                        |
| [`5384a35a`](https://github.com/NixOS/nixpkgs/commit/5384a35a0c5198e224435b7295b3d273e645243d) | `haskell.compiler.ghc*Binary: add all missing runtimeDeps to PATH`        |
| [`579bc49e`](https://github.com/NixOS/nixpkgs/commit/579bc49e9485b337b0b13671fc3e368c6c93483b) | `haskell.compiler.ghc*Binary: don't propagate LLVM, use wrapper`          |
| [`b637d805`](https://github.com/NixOS/nixpkgs/commit/b637d805c1c3d754c5e81cb4d1d865edcd7b9ed0) | `ocamlPackages.ocsigen-start: switch to fetchFromGitHub`                  |
| [`659d63ee`](https://github.com/NixOS/nixpkgs/commit/659d63ee57ce5e100c99d820327af957f03ee2f6) | `ocamlPackages.lwt_ssl: switch to fetchFromGitHub`                        |
| [`bb7d1274`](https://github.com/NixOS/nixpkgs/commit/bb7d12745b9e2d7ee9c2356c89569ac53d45a50c) | `ocamlPackages.macaque: switch to fetchFromGitHub`                        |
| [`8889d3c9`](https://github.com/NixOS/nixpkgs/commit/8889d3c9688709712050944bff0fa3e38b6072ae) | `ocamlPackages.markup: switch to fetchFromGitHub`                         |
| [`fa8d1b35`](https://github.com/NixOS/nixpkgs/commit/fa8d1b35aa1f80d0d48557b31ab6faf92f426afa) | `ocamlPackages.ocplib-endian: switch to fetchFromGitHub`                  |
| [`88e5a0b3`](https://github.com/NixOS/nixpkgs/commit/88e5a0b3444c97f1ae284c43106aa30a845037f2) | `ocamlPackages.ocsigen-deriving: switch to fetchFromGitHub`               |
| [`3f07af26`](https://github.com/NixOS/nixpkgs/commit/3f07af266bd92c703f92d797efeddde305c20139) | `ocamlPackages.optcomp: switch to fetchFromGitHub`                        |
| [`a4fbb5f7`](https://github.com/NixOS/nixpkgs/commit/a4fbb5f7d030e5db072740d215a0fc27960bcb49) | `ocamlPackages.pa_bench: switch to fetchFromGitHub`                       |
| [`9ebeffd3`](https://github.com/NixOS/nixpkgs/commit/9ebeffd3c68af7069ca86cdfb06f4b6e86f75f02) | `ocamlPackages.pa_ounit: switch to fetchFromGitHub`                       |
| [`078b39b1`](https://github.com/NixOS/nixpkgs/commit/078b39b1e956993d73658b515aec010f97bc9361) | `ocamlPackages.pipebang: switch to fetchFromGitHub`                       |
| [`d6d81950`](https://github.com/NixOS/nixpkgs/commit/d6d8195058f547cecdbecae16ed1cda7df4c4715) | `ocamlPackages.reactivedata: switch to fetchFromGitHub`                   |
| [`b2c2215f`](https://github.com/NixOS/nixpkgs/commit/b2c2215f606426a8bc8368b344f14a5123f14f3c) | `pkgsMusl.haskell.compiler.ghc884: return accurate platforms`             |
| [`55b8d8c1`](https://github.com/NixOS/nixpkgs/commit/55b8d8c1bfd055f7efecf175fb7e528b193d2762) | `haskell.compiler.ghc884: re-enable aarch64-linux`                        |
| [`b9f15821`](https://github.com/NixOS/nixpkgs/commit/b9f15821064edcb61d9c5e06285fbbde775edeb9) | `haskell.compiler.ghc865Binary: remove aarch64-linux from platforms`      |
| [`9e1f438a`](https://github.com/NixOS/nixpkgs/commit/9e1f438a7656b5ab2247eca914902525207f12cc) | `haskell.compiler.*: upgrade to latest supported LLVM version`            |
| [`5a568ea3`](https://github.com/NixOS/nixpkgs/commit/5a568ea36fc596b349ac088418c627d4a1488ce0) | `haskell.compiler.ghc901: drop LLVM version to 9`                         |
| [`d7ff8061`](https://github.com/NixOS/nixpkgs/commit/d7ff8061beed6ce1c141066fd268cdbb5acc0dd1) | `haskellPackages: always inherit llvmPackages from ghc's passthru`        |
| [`e1913218`](https://github.com/NixOS/nixpkgs/commit/e191321866b1d754eed23a577837f183c76581f7) | `haskell.compiler.ghc865Binary: build with correct LLVM version`          |
| [`34f54b0c`](https://github.com/NixOS/nixpkgs/commit/34f54b0c83013bc57dc9ecbcba5d427d15ddc6d3) | `bash: Quote variable reference`                                          |
| [`10e89127`](https://github.com/NixOS/nixpkgs/commit/10e89127994fbeebf7f1cf07df49e9c53bd7eca1) | `numix-cursor-theme: Define pname`                                        |
| [`21ca2dec`](https://github.com/NixOS/nixpkgs/commit/21ca2dec9ffcfb3bf8c1435eea443b999c7e5193) | `pyscf: 1.7.6.post1 -> 2.0.1`                                             |
| [`938a9e00`](https://github.com/NixOS/nixpkgs/commit/938a9e00c5b253bfb4e3d51c0b63cfc7a8253d24) | `cppe: init at 0.3.1`                                                     |
| [`a6a51146`](https://github.com/NixOS/nixpkgs/commit/a6a5114653c90cf8a4bc779b219a0bb03a647061) | `python3.pkgs.polarizationsolver: init at 00424ac4`                       |
| [`dbd7ba5f`](https://github.com/NixOS/nixpkgs/commit/dbd7ba5f5f0865f2b2e9ec5c303ee4979a4679a5) | `python3.pkgs.fields: init at 5.0.0`                                      |
| [`2a9baed9`](https://github.com/NixOS/nixpkgs/commit/2a9baed9062f60d06849aabd41bae916f714f508) | `libxc: force 3rd and 4th derivatives compilation`                        |
| [`dd7f5873`](https://github.com/NixOS/nixpkgs/commit/dd7f587346aa6f57e25628643149982041e02655) | `libcint: 4.4.0 -> 4.4.6`                                                 |
| [`4e77334d`](https://github.com/NixOS/nixpkgs/commit/4e77334d2c176b125193205fa78647158458a0ba) | `numix-cursor-theme: 1.1 -> 1.2`                                          |
| [`184f8532`](https://github.com/NixOS/nixpkgs/commit/184f85323948abbcfa5e079bb3684a7ab7bf315d) | `aws-c-io: 0.10.12 -> 0.10.13`                                            |
| [`f09fff1e`](https://github.com/NixOS/nixpkgs/commit/f09fff1e1f0d6a671f713006367474314dc5649f) | `aws-c-cal: 0.5.11 -> 0.5.12`                                             |
| [`181ee83b`](https://github.com/NixOS/nixpkgs/commit/181ee83bff05cf9ae056e703ca87c018f27713d7) | `aws-c-mqtt: 0.7.8 -> 0.7.9`                                              |
| [`ec720845`](https://github.com/NixOS/nixpkgs/commit/ec720845982d64209866288c55a749a56a150681) | `aws-c-auth: 0.6.5 -> 0.6.8`                                              |
| [`59292410`](https://github.com/NixOS/nixpkgs/commit/592924102351bcc3133e7a244722ebd3a6e88562) | `s2n-tls: 1.0.17 -> 1.3.0`                                                |
| [`467aead3`](https://github.com/NixOS/nixpkgs/commit/467aead38e5092f9550a0c84dde43af4e792043b) | `pulseaudio-dlna: unstable-2017-11-01 -> unstable-2021-11-09`             |
| [`2eb081de`](https://github.com/NixOS/nixpkgs/commit/2eb081deb2327d44c78d0ed5cc3c32b5010f0297) | `aws-crt-cpp: 0.17.0 -> 0.17.8`                                           |
| [`ea80624c`](https://github.com/NixOS/nixpkgs/commit/ea80624cdc9e5d1718f4d53ade4abdb6aa7d2367) | `aws-c-http: 0.6.8 -> 0.6.10`                                             |
| [`9d21602e`](https://github.com/NixOS/nixpkgs/commit/9d21602e75d7383cf2ee01fa657f423f205c7805) | `aws-c-common: 0.6.14 -> 0.6.17`                                          |
| [`b8c07fac`](https://github.com/NixOS/nixpkgs/commit/b8c07facaa578c05af95fb4b2479bdfd9a433e31) | `Fix eval with `nix-env -qas``                                            |
| [`d729328f`](https://github.com/NixOS/nixpkgs/commit/d729328f201216ecf34ffac64e19b013b4c01a75) | `pspg: 5.4.1 -> 5.5.0`                                                    |