### PR TITLE
chore(flake/nixpkgs): `fb41277d` -> `089cfc88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638133678,
-        "narHash": "sha256-iYpfV+O1RwFZvDBpWgNDO5JfSOTCe456j457L22JYs0=",
+        "lastModified": 1638177417,
+        "narHash": "sha256-gEnOouBnwaXVlrW5/Mz9jEGu/QODYZvF5xatkAdRC10=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fb41277df396a390a08a3b3afa57f122df618d4b",
+        "rev": "089cfc889484931f8f124e449d9e15cc67ad1e33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`2d4606a3`](https://github.com/NixOS/nixpkgs/commit/2d4606a32d27b5c1429574dc72487490206b5aa8) | `qt4: pull upstream fix for gcc-11 (#147555)`                                       |
| [`ee1f1e0e`](https://github.com/NixOS/nixpkgs/commit/ee1f1e0e4ee17729b312f96e91f47ada20b9f36e) | `dbeaver: 21.2.5 -> 21.3.0`                                                         |
| [`5b861824`](https://github.com/NixOS/nixpkgs/commit/5b861824b3fad451955ff373ebdb6af2175a85e4) | `compcert: 3.9 → 3.10`                                                              |
| [`9a3b63e9`](https://github.com/NixOS/nixpkgs/commit/9a3b63e9f1f11d0434432ac91a750f6e6d963a78) | `spyder-kernels: fix build`                                                         |
| [`d6a2e581`](https://github.com/NixOS/nixpkgs/commit/d6a2e5815e53c8fa3346d9a151a1f4430af1907c) | `cppcheck: 2.5 -> 2.6 (#147713)`                                                    |
| [`77e9c5d3`](https://github.com/NixOS/nixpkgs/commit/77e9c5d38c1a218950b31e9c537a3136baf97c99) | `stig: fix build`                                                                   |
| [`20bb15cf`](https://github.com/NixOS/nixpkgs/commit/20bb15cfa0ab663a8aa4682da7e0f4d0f032380e) | `linux_hardkernel_4_14: 4.14.165-172 -> 4.14.180-176`                               |
| [`82b9b426`](https://github.com/NixOS/nixpkgs/commit/82b9b4268207f1af23486018254dbc521464c8b9) | `Fix some nixos-rebuild lints (#147449)`                                            |
| [`3aab0e3a`](https://github.com/NixOS/nixpkgs/commit/3aab0e3ad9ef9663566c9c915b93922b4158d5ff) | `Fix typo in Octave description (#147799)`                                          |
| [`e1486fee`](https://github.com/NixOS/nixpkgs/commit/e1486feead37cacbc9726fba9c20c4fbc28b2b37) | `maintainers: winterqt -> winter`                                                   |
| [`3eb5d85b`](https://github.com/NixOS/nixpkgs/commit/3eb5d85beb8f126def8dbf7b35035826bd7dd58f) | `.github/workflows/periodic-merge: configure 21.11 release`                         |
| [`4aa2320e`](https://github.com/NixOS/nixpkgs/commit/4aa2320ec14b185e0a601b108c3d970f6bba22c8) | `vorta: 0.7.8 -> 0.8.2`                                                             |
| [`fdc128b1`](https://github.com/NixOS/nixpkgs/commit/fdc128b146fcc7a9c4f3bc50f1cf511abe184152) | `iterm2: 3.4.13 -> 3.4.14`                                                          |
| [`e8f3312a`](https://github.com/NixOS/nixpkgs/commit/e8f3312aab52e0318c0b4c34e61622e9d516fedc) | `amass: 3.15.0 -> 3.15.1`                                                           |
| [`0a9dd29c`](https://github.com/NixOS/nixpkgs/commit/0a9dd29c98c6dd720bfb9e5e6d8a3b551fc71d94) | `netatalk: fix build`                                                               |
| [`81fb8b76`](https://github.com/NixOS/nixpkgs/commit/81fb8b76317c509098fbcccf4f7ca086603f2201) | `pipe-rename: 1.4.0 -> 1.4.1`                                                       |
| [`1c8513df`](https://github.com/NixOS/nixpkgs/commit/1c8513dfe4af5220d7a6d3c259471b502d2be84e) | `difftastic: 0.11.0 -> 0.12.0`                                                      |
| [`cda6d383`](https://github.com/NixOS/nixpkgs/commit/cda6d383462cce9e5d6f1848480c3322c4dff92b) | `statix: 0.4.0 -> 0.4.1`                                                            |
| [`d26a0b8d`](https://github.com/NixOS/nixpkgs/commit/d26a0b8d9f520fc3d8c19fcb6efb877587270024) | `cargo-sort: 1.0.5 -> 1.0.6`                                                        |
| [`d18a44ab`](https://github.com/NixOS/nixpkgs/commit/d18a44ab6dff396fd3cdd439406933c3369cb2eb) | `ttyper: 0.3.0 -> 0.3.1`                                                            |
| [`8153160a`](https://github.com/NixOS/nixpkgs/commit/8153160acfd08328adf0f32bb5a4358cb77a2ab4) | `glitter: 1.5.6 -> 1.5.7`                                                           |
| [`32067bb1`](https://github.com/NixOS/nixpkgs/commit/32067bb1597fdbf762a4b55c81e7788a5c2149cd) | `neard: fix build`                                                                  |
| [`9366d120`](https://github.com/NixOS/nixpkgs/commit/9366d120364a6a0106f6379838abe98d69307ed6) | `hck: 0.7.0 -> 0.7.1`                                                               |
| [`1e3b8e3f`](https://github.com/NixOS/nixpkgs/commit/1e3b8e3fd835832864d8038d9d6bb906372a764e) | `python3Packages.pywal: use $TMPDIR in tests`                                       |
| [`b9f6ee2e`](https://github.com/NixOS/nixpkgs/commit/b9f6ee2e2f1cde415b610619e154d6b452583460) | `pijul: 1.0.0-alpha.55 → 1.0.0-alpha.56`                                            |
| [`87304227`](https://github.com/NixOS/nixpkgs/commit/873042271ad597dd77c95d380f75f05f6185249e) | `frogatto: 2021-05-24 -> 2021-11-23`                                                |
| [`bf2b9f5e`](https://github.com/NixOS/nixpkgs/commit/bf2b9f5e872a342e5d46e8c33649b07c90488b36) | `python3Packages.zigpy-deconz: 0.13.0 -> 0.14.0`                                    |
| [`6f12741e`](https://github.com/NixOS/nixpkgs/commit/6f12741ec6312ee2e11042d63aff068efbe3c4fd) | `python3Packages.bellows: 0.28.0 -> 0.29.0`                                         |
| [`2cdf3f47`](https://github.com/NixOS/nixpkgs/commit/2cdf3f4756254bcba0a352103badbb9ed8df5984) | `python3Packages.time-machine: 2.4.0 -> 2.4.1`                                      |
| [`f7e3d421`](https://github.com/NixOS/nixpkgs/commit/f7e3d421be36daca404824f057b9e1d2eb7e631e) | `dnsperf: 2.5.2 -> 2.8.0`                                                           |
| [`490652c6`](https://github.com/NixOS/nixpkgs/commit/490652c67e1dcba73d293b04e7301437dc72bc24) | `enum4linux: 0.8.9 -> 0.9.1`                                                        |
| [`566844ae`](https://github.com/NixOS/nixpkgs/commit/566844aed380bce16e38f4ee7076f64aed3a3919) | `python3Packages.socialscan: init at 1.4.2`                                         |
| [`ea11ede7`](https://github.com/NixOS/nixpkgs/commit/ea11ede71b7634e745811fe0f3fb4b81a8135751) | `python3Packages.python-smarttub: 0.0.27 -> 0.0.28`                                 |
| [`078a4f9f`](https://github.com/NixOS/nixpkgs/commit/078a4f9f3fe7373f774e6ca17a269280745c970d) | `cinnamon.cinnamon-common: fix #146507 online-accounts in cinnamon-settings broken` |
| [`c11c15c7`](https://github.com/NixOS/nixpkgs/commit/c11c15c7322dc07369fdce78d23cc1c061e379d0) | `python3.pkgs.xapp: 2.0.2 -> 2.2.1`                                                 |
| [`a5f5b39a`](https://github.com/NixOS/nixpkgs/commit/a5f5b39a976ed85abd6c60857191d217f729642d) | `cinnamon.xapps: 2.2.3 -> 2.2.5`                                                    |
| [`56ba20a3`](https://github.com/NixOS/nixpkgs/commit/56ba20a3138d122e9ce91d2a68e48889f0c3f6f6) | `cinnamon.warpinator: 1.0.8 -> 1.2.5`                                               |
| [`b6490745`](https://github.com/NixOS/nixpkgs/commit/b64907452c37cb89bd3cb6bc76de154f6a50c81b) | `cinnamon.nemo: 5.0.3 -> 5.2.0`                                                     |
| [`a8d1dab1`](https://github.com/NixOS/nixpkgs/commit/a8d1dab1a8755503e06791a07c73859e6a464e1d) | `cinnamon.muffin: 4.8.1 -> 5.2.0`                                                   |
| [`c27e5b5e`](https://github.com/NixOS/nixpkgs/commit/c27e5b5e9d55b91c2ff75d69e2ce6b407839c439) | `cinnamon.mint-y-icons: 1.4.3 -> 1.5.8`                                             |
| [`11372c16`](https://github.com/NixOS/nixpkgs/commit/11372c16cfaa82b7d7042da367a287eff0c5ae90) | `cinnamon.mint-x-icons: 1.5.5 -> 1.6.3`                                             |
| [`652b0ea6`](https://github.com/NixOS/nixpkgs/commit/652b0ea6fa0ae8b0619842bbdae55acfd49b73aa) | `cinnamon.mint-themes: 1.8.6 -> 1.8.8`                                              |
| [`403e4d7a`](https://github.com/NixOS/nixpkgs/commit/403e4d7af6c8f6feff903e0a8a78ae3bce9de238) | `cinnamon.mint-artwork: 1.4.3 -> 1.5.4`                                             |
| [`b4aa62ec`](https://github.com/NixOS/nixpkgs/commit/b4aa62ec19b1110df9224037b412b7f5330b99e3) | `cinnamon.cjs: 4.8.2 -> 5.2.0`                                                      |
| [`d9ab6ff3`](https://github.com/NixOS/nixpkgs/commit/d9ab6ff3ffa4fd3bb512e091ac79e98d20720f06) | `cinnamon.cinnamon-translations: 5.0.0 -> 5.2.0`                                    |
| [`5ec4f8bf`](https://github.com/NixOS/nixpkgs/commit/5ec4f8bf7f659500c3b04918a90ded7963a42fde) | `cinnamon.cinnamon-settings-daemon: 4.8.5 -> 5.2.0`                                 |
| [`575e61ac`](https://github.com/NixOS/nixpkgs/commit/575e61ac7f1fb2d25ca07e08afdd5e2a2c8c89ba) | `cinnamon.cinnamon-session: 4.8.0 -> 5.2.0`                                         |
| [`36bab07f`](https://github.com/NixOS/nixpkgs/commit/36bab07f0c982fedb7f825b26183525c7876368a) | `cinnamon.cinnamon-screensaver: 4.8.1 -> 5.2.0`                                     |
| [`8e9cc073`](https://github.com/NixOS/nixpkgs/commit/8e9cc0733c2a3c3a0a96b0320500f09beb4e01c6) | `cinnamon.cinnamon-menus: 4.8.2 -> 5.2.0`                                           |
| [`bd0acde3`](https://github.com/NixOS/nixpkgs/commit/bd0acde36882e22f94d6a996b5e2355778c7efd4) | `cinnamon.cinnamon-desktop: 4.8.1 -> 5.2.0`                                         |
| [`3226fb88`](https://github.com/NixOS/nixpkgs/commit/3226fb88d4f6a29d3c32e28dd2e3b18ae38c51bb) | `cinnamon.cinnamon-control-center: 4.8.2 -> 5.2.0`                                  |
| [`a0cbed6f`](https://github.com/NixOS/nixpkgs/commit/a0cbed6fb9702313de63ac5a9a32858513ac12ce) | `cinnamon.cinnamon-common: 4.8.6 -> 5.2.0`                                          |
| [`0733df83`](https://github.com/NixOS/nixpkgs/commit/0733df83f8ca90bb2c993c371269c71c4d59d4ea) | `cinnamon.bulky: 1.7 -> 1.9`                                                        |
| [`df84399f`](https://github.com/NixOS/nixpkgs/commit/df84399f53cf5a7ae5a74ff9e05431bf0429009d) | `cinnamon.pix: init at 2.6.5`                                                       |
| [`db93a29e`](https://github.com/NixOS/nixpkgs/commit/db93a29ef36e0177989e01da5eda102a723896b8) | `cinnamon.xreader: init at 3.0.2`                                                   |
| [`3de6d756`](https://github.com/NixOS/nixpkgs/commit/3de6d756d165f39da9c754b964650dacd02b1dc8) | `cinnamon.bulky: make team cinnamon the maintainer`                                 |
| [`5a5617a2`](https://github.com/NixOS/nixpkgs/commit/5a5617a2be8dc48297ef54aae8e9062148d2ea52) | `cinnamon.cinnamon-settings-daemon: make team cinnamon the maintainer`              |
| [`1ed9d6b5`](https://github.com/NixOS/nixpkgs/commit/1ed9d6b5f934dc5f8f44b6d8d81a564715bfe6a5) | `cinnamon.mint-artwork: add meta`                                                   |
| [`f5d3fd82`](https://github.com/NixOS/nixpkgs/commit/f5d3fd8276f60ba524c8144f2f4038593b2b7f55) | `cinnamon.warpinator: make team cinnamon the maintainer`                            |
| [`4bf3f51a`](https://github.com/NixOS/nixpkgs/commit/4bf3f51a0010e922e4dfc262551edbaca5d08662) | `cinnamon.xviewer: add team cinnamon as maintainer`                                 |
| [`7aff8112`](https://github.com/NixOS/nixpkgs/commit/7aff8112926043de70ef9b709ce954abc9630863) | `nixos/cinnamon: add xapps to extra app list`                                       |
| [`c5b6e8a0`](https://github.com/NixOS/nixpkgs/commit/c5b6e8a0fd39426e47349524ceb29c1a4d8328c8) | `python3Packages.qiskit-aqua: disable slow tests`                                   |
| [`ddcf2bb8`](https://github.com/NixOS/nixpkgs/commit/ddcf2bb8c1911aa4c46b08cd4d711d6389f348ca) | `pwndbg: update ropgadget`                                                          |
| [`ba01d17d`](https://github.com/NixOS/nixpkgs/commit/ba01d17d49d4ebed6ad5755932c620aeb2052e48) | `python3Packages.pwntools: update ropgadget`                                        |
| [`112d6127`](https://github.com/NixOS/nixpkgs/commit/112d6127a098651d4232809a128e54d1d91a1c65) | `python3Packages.ropgadget: rename from ROPGadget`                                  |
| [`cb7d50dc`](https://github.com/NixOS/nixpkgs/commit/cb7d50dc6a81dc470cbb744de8473f8a881ec4fe) | `python3Packages.ROPGadget: 6.5 -> 6.6`                                             |
| [`3d5d225b`](https://github.com/NixOS/nixpkgs/commit/3d5d225ba19fb22a89407b370e2d81b46643f6f6) | `crd2pulumi: init at 1.0.10`                                                        |