### PR TITLE
chore(flake/poetry2nix): `36c215f7` -> `41732777`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1637956502,
-        "narHash": "sha256-ahNiWkjy1xhbryHCi6i0s2K9N8tD5vX6QroK4d5/Vo4=",
+        "lastModified": 1638221212,
+        "narHash": "sha256-q0538K4nzLlhQoDV1lvNZgONlkW/KmFAoMfVET2G8uU=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "36c215f7161b0a051be207ab7b31c37d17b025b4",
+        "rev": "417327774668d33c7792c1f8b20407a550b66517",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                    | Commit Message                                   |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`42b1e673`](https://github.com/nix-community/poetry2nix/commit/42b1e673aa5a9c9236a86ae93d100ddcaf997108) | `Include the trailing slash in legacy index URL` |