### PR TITLE
chore(flake/nixpkgs): `089cfc88` -> `33ef578c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638177417,
-        "narHash": "sha256-gEnOouBnwaXVlrW5/Mz9jEGu/QODYZvF5xatkAdRC10=",
+        "lastModified": 1638220705,
+        "narHash": "sha256-HpRLe61ZysTcZcZUB6ZLyBZGQ5e+/NgGKvTE6sDGqaI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "089cfc889484931f8f124e449d9e15cc67ad1e33",
+        "rev": "33ef578c3d4931c73db0f546d9e84fa2ec1fa65d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`11313ae4`](https://github.com/NixOS/nixpkgs/commit/11313ae4112f884e5d70bc342d361726c69cf3e2) | `nwjs: 0.33.4 -> 0.54.1`                                                  |
| [`8ecf2d61`](https://github.com/NixOS/nixpkgs/commit/8ecf2d613aa3cf56821604df894dc2b90f4b128b) | `symfony-cli: support more platforms (#147732)`                           |
| [`dbd39c4d`](https://github.com/NixOS/nixpkgs/commit/dbd39c4d41fb8ef843e1a621dfa47c30e58a3061) | `pgbouncer: 1.16.0 -> 1.16.1`                                             |
| [`14a87afd`](https://github.com/NixOS/nixpkgs/commit/14a87afdf87a6660b9edceb1d8879d96161c8302) | `bitwig-studio: 4.0.7 -> 4.1`                                             |
| [`a4977db2`](https://github.com/NixOS/nixpkgs/commit/a4977db2e8984d7976163f22331711bd99c56286) | `caddy: include and utilize systemd service from upstream (#147305)`      |
| [`03e4ad17`](https://github.com/NixOS/nixpkgs/commit/03e4ad1709e48118498155c7f1ecc8473bd40b2c) | `sumneko-lua-language-server: 2.4.7 -> 2.5.1`                             |
| [`37108292`](https://github.com/NixOS/nixpkgs/commit/371082920f97f54f90d8e78fe12e0253ffb2e5bb) | `zoom-us: 5.8.4.210 -> 5.8.6.739`                                         |
| [`6bd0a5be`](https://github.com/NixOS/nixpkgs/commit/6bd0a5beac9618aeb25124074c4bc197df3b8703) | `glean-parser: disable pytest-runner`                                     |
| [`887d55c9`](https://github.com/NixOS/nixpkgs/commit/887d55c92f5d86e86303be320883a92366bc901d) | `unifi6: 6.4.54 -> 6.5.53`                                                |
| [`eb803527`](https://github.com/NixOS/nixpkgs/commit/eb80352750e7793a5d5a00a6eeceeeb2a7b04c0f) | `ookla-speedtest: 1.1.0 -> 1.1.1`                                         |
| [`b7199d24`](https://github.com/NixOS/nixpkgs/commit/b7199d242e645d8ea41bd991cc17a7021fcf5a40) | `musescore: Fix some qt issues`                                           |
| [`24fb8db6`](https://github.com/NixOS/nixpkgs/commit/24fb8db66d32105d05f82f154e4820d079026313) | `ucx: add optional Cuda support`                                          |
| [`6d3cfa53`](https://github.com/NixOS/nixpkgs/commit/6d3cfa53d6cd7d776a1b61c7a529ac8949c9d4e0) | `vintagestory: 1.15.5 -> 1.15.10`                                         |
| [`227a7072`](https://github.com/NixOS/nixpkgs/commit/227a7072d059e31738131b0573def3cd321cf4aa) | `pistol: 0.2.2 -> 0.3.1`                                                  |
| [`be952aba`](https://github.com/NixOS/nixpkgs/commit/be952aba1cff795f61f1608cb265b829c57fcb8e) | `nixos/acme: Fix rate limiting of selfsigned services`                    |
| [`31247c8e`](https://github.com/NixOS/nixpkgs/commit/31247c8e5693eb98d48b3cb0e36ec423a613958c) | `stig: reenable test not failing on Linux`                                |
| [`f832949b`](https://github.com/NixOS/nixpkgs/commit/f832949b5ffea27299243fda74e7b59f933dbd38) | `home-assistant: pin PyChromecast to 9.4.0`                               |
| [`a5552c62`](https://github.com/NixOS/nixpkgs/commit/a5552c62db137a9316699a2db19c498d34596c8e) | `obelisk: 0.5.2 → 0.6.0`                                                  |
| [`041de05c`](https://github.com/NixOS/nixpkgs/commit/041de05c3d2630193c520b62de8e63d8d295f72b) | `coqPackages.coqhammer: 1.3.1 → 1.3.2`                                    |
| [`680822a3`](https://github.com/NixOS/nixpkgs/commit/680822a336b4ba77727548e08e6bd3a2df0f4eb1) | `python3Packages.fakeredis: 1.6.1 -> 1.7.0`                               |
| [`f14c69a5`](https://github.com/NixOS/nixpkgs/commit/f14c69a5bc664db3d738fd0b0c0780251c3ad464) | `checkov: 2.0.605 -> 2.0.606`                                             |
| [`2d445881`](https://github.com/NixOS/nixpkgs/commit/2d445881d4a8270118e044a4dc6102cbf4caac53) | `tfsec: 0.61.0 -> 0.61.2`                                                 |
| [`362ae7e7`](https://github.com/NixOS/nixpkgs/commit/362ae7e7f58b0958daf5d27e6b5c53b00c008a32) | `go-task: 3.9.0 -> 3.9.1`                                                 |
| [`6eb8b524`](https://github.com/NixOS/nixpkgs/commit/6eb8b52444207b52b100a2f23b6b01ca712b31ec) | `dateutils: enable on darwin`                                             |
| [`25a9d1ba`](https://github.com/NixOS/nixpkgs/commit/25a9d1ba9ee109528d35ce4b38823e0e323df8c9) | `mediawiki: drop redvers from maintainers`                                |
| [`a0e1114e`](https://github.com/NixOS/nixpkgs/commit/a0e1114e17cefc96d9a69539217e2ed2d9383986) | `mediawiki: 1.36.2 -> 1.37.0`                                             |
| [`cd12d81d`](https://github.com/NixOS/nixpkgs/commit/cd12d81d53de56b50b589bfd71cef8c245c7de88) | `mediawiki: 1.36.1 -> 1.36.2`                                             |
| [`8a69eb87`](https://github.com/NixOS/nixpkgs/commit/8a69eb87010bfcde3cd23e75472ccb7b7d33f6b0) | `ncgopher: 0.2.0 -> 0.3.0`                                                |
| [`ef8eb896`](https://github.com/NixOS/nixpkgs/commit/ef8eb89693a979c6dac738ea26141107408832f6) | `piping-server-rust: 0.9.1 -> 0.10.1`                                     |
| [`25b1292d`](https://github.com/NixOS/nixpkgs/commit/25b1292db1f5da73680aed7a2a7a8a486b19eab2) | `xfce.xfce4-whiskermenu-plugin: 2.6.2 -> 2.7.0`                           |
| [`30fb90c1`](https://github.com/NixOS/nixpkgs/commit/30fb90c16b1d9ed80d6e1f9458cb377ab065ec97) | `xfce.ristretto: 0.12.0 -> 0.12.1`                                        |
| [`6d5f693e`](https://github.com/NixOS/nixpkgs/commit/6d5f693e8844835f5f7d673d068169f807bcd51f) | `xfce.mousepad: 0.5.7 -> 0.5.8`                                           |
| [`63a36957`](https://github.com/NixOS/nixpkgs/commit/63a3695759bc8640ee9782637c21fe9b91726ffe) | `csview: 0.3.8 -> 0.3.9`                                                  |
| [`36857fb2`](https://github.com/NixOS/nixpkgs/commit/36857fb291114460a01f37b8153326fa26f7011d) | `vimPlugins: resolve github repository redirects`                         |
| [`b86ff229`](https://github.com/NixOS/nixpkgs/commit/b86ff2299acdc0ddf7bbc2f35c33ff16de9f285f) | `vimPlugins: update`                                                      |
| [`1ca74a00`](https://github.com/NixOS/nixpkgs/commit/1ca74a0074d166def72ccf810ca021b66aab2996) | `libdeltachat: 1.67.0 -> 1.68.0`                                          |
| [`3f3dd1d0`](https://github.com/NixOS/nixpkgs/commit/3f3dd1d0c9072f3a32a4c4ff1fafdf4e3724b4ff) | `vwm: fix build against ncurses-6.3`                                      |
| [`54765edc`](https://github.com/NixOS/nixpkgs/commit/54765edc0bc6e349d52d46e7d52ee98e02c161d1) | `libviper: fix build against ncurses-6.3`                                 |
| [`387b85da`](https://github.com/NixOS/nixpkgs/commit/387b85da72c12f94fb9d9558c1c834a4df6d6f57) | `liboping: pull pending upstream inclusion fix for ncurses-6.3`           |
| [`722bfae4`](https://github.com/NixOS/nixpkgs/commit/722bfae4875783c086bbd102a63c16eb6f93ad33) | `libreoffice-fresh: 7.2.2.2 -> 7.2.3.2`                                   |
| [`b3c9ba1d`](https://github.com/NixOS/nixpkgs/commit/b3c9ba1d03b2207c2a45eea9c1996fbf11d4c9eb) | `cloud-init: 21.2 -> 21.4`                                                |
| [`69f1acd3`](https://github.com/NixOS/nixpkgs/commit/69f1acd3ecc1b3879275bf4ecb330cdd7f1735bc) | `build-idris-package: Use patchPhase for consistency`                     |
| [`55d436b1`](https://github.com/NixOS/nixpkgs/commit/55d436b1e7f280f8b072758696c28c30dadde853) | `dockapps.wmsm-app: Avoid segfault in build`                              |
| [`8e89d684`](https://github.com/NixOS/nixpkgs/commit/8e89d68448770c4b47621f15c961dfbb6488b403) | `gsl_1: enable parallel building`                                         |
| [`59221864`](https://github.com/NixOS/nixpkgs/commit/592218648c26454862920beb5e891be92ac728e8) | `augustus: 3.0.1 -> 3.1.0`                                                |
| [`45e0ffb3`](https://github.com/NixOS/nixpkgs/commit/45e0ffb3ccf6733d6d57fe6906f59b333089359e) | `python3Packages.libarchive-c: 3.1 -> 3.2`                                |
| [`0d83270c`](https://github.com/NixOS/nixpkgs/commit/0d83270c4693f8c9d0341ccf2943a3e99459dcad) | `lagrange: 1.7.3 → 1.9.0`                                                 |
| [`0360e035`](https://github.com/NixOS/nixpkgs/commit/0360e035207bc99db533eb2e10e15270d1cd6fbf) | `nixos/install-grub: fix whitespace`                                      |
| [`19447850`](https://github.com/NixOS/nixpkgs/commit/19447850a2e0ce26141452bb46da1267cdd11269) | `Revert "nixos/install-grub: normalize whitespace"`                       |
| [`aab65a36`](https://github.com/NixOS/nixpkgs/commit/aab65a362ed0e902c6a3e662047d80336bce3b01) | `krane: 2.3.2 → 2.3.4`                                                    |
| [`dbda557c`](https://github.com/NixOS/nixpkgs/commit/dbda557c643b16b7646615d8e82e39bf607abe0c) | `steamPackages.steam-runtime: 0.20210906.1 -> 0.20211102.0`               |
| [`8b154985`](https://github.com/NixOS/nixpkgs/commit/8b154985f37cb9148c08f9e410f3333ff214dd4a) | `edk2: use llvmPackages_9.stdenv`                                         |
| [`a805549e`](https://github.com/NixOS/nixpkgs/commit/a805549e43843f9f799531fe11cc4a62164e1fd8) | `privacyidea: 3.6.2 -> 3.6.3`                                             |
| [`8147fb68`](https://github.com/NixOS/nixpkgs/commit/8147fb683c111f40da54d245c965517bd2885b43) | `samtools: pull upstream fix for ncurses-6.3`                             |
| [`b93e9efd`](https://github.com/NixOS/nixpkgs/commit/b93e9efd75b0af6175349e32bcc83be09c28a18b) | `safe: 1.5.1 -> 1.6.1`                                                    |
| [`e6768591`](https://github.com/NixOS/nixpkgs/commit/e67685910d38948bf62e64142306778f20743d45) | `mastodon: 3.4.1 -> 3.4.4`                                                |
| [`daf2b0f9`](https://github.com/NixOS/nixpkgs/commit/daf2b0f91719368aed574fb476aaf83a0c116940) | `mastodon.updateScript: use runCommand instead of mkDerivation`           |
| [`44a15ab8`](https://github.com/NixOS/nixpkgs/commit/44a15ab801feea4c1dcc1c25795f6658a570ed01) | `lib/tests: Use standard test syntax`                                     |
| [`b8f8589e`](https://github.com/NixOS/nixpkgs/commit/b8f8589e9a65136eaaa703ae7f628e3c9b30fc87) | `lib/tests: Anchor config output regexes`                                 |
| [`989f034f`](https://github.com/NixOS/nixpkgs/commit/989f034ff1f8f5f3287074d4569cfd199e857ea1) | `lib/tests: Set hardening pragmas`                                        |
| [`bfc580f5`](https://github.com/NixOS/nixpkgs/commit/bfc580f54fb90295f7375ae166446e334e6ebd17) | `lib/tests: Don't return non-zero values from checks`                     |
| [`40ae711f`](https://github.com/NixOS/nixpkgs/commit/40ae711f7387565b6be25d6d34424f9ede0154a0) | `lib/tests: Avoid assigning an array to a string`                         |
| [`04223a0d`](https://github.com/NixOS/nixpkgs/commit/04223a0d436f91f3205e901d2d2ffed2f9afbbf6) | `lib/tests: Remove redundant semicolons`                                  |
| [`41fd1d86`](https://github.com/NixOS/nixpkgs/commit/41fd1d8626ff890a28c43062e39c5318e72af35e) | `lib/tests: Clarify assignment`                                           |
| [`5e85cd86`](https://github.com/NixOS/nixpkgs/commit/5e85cd86afd4688ad9c1da8be8dbf1a0d35c9cf2) | `lib/tests: Use correct shebang line`                                     |
| [`40d1c87b`](https://github.com/NixOS/nixpkgs/commit/40d1c87bea38b3937fd4837cbb93fed7be4ffd1d) | `lib/tests: Quote variable references`                                    |
| [`0235225a`](https://github.com/NixOS/nixpkgs/commit/0235225a3c1afbe92bd3dfc070242108b6c4af6e) | `zsh-better-npm-completion: init at unstable-2019-11-19`                  |
| [`6d53055c`](https://github.com/NixOS/nixpkgs/commit/6d53055cb742e2b04511382f9cdbf9e41ec41f14) | `lib/tests: `export` separately from assignment`                          |
| [`8cf96b94`](https://github.com/NixOS/nixpkgs/commit/8cf96b94264402e958908862991c281999483d3a) | `stdenv: patch autoconf script for riscv in stage 2`                      |
| [`fc3ea54f`](https://github.com/NixOS/nixpkgs/commit/fc3ea54fb3d97865dc2bb173c3a5ea54eaf1ad13) | `make-bootstrap-tools: produce libatomic on riscv platform`               |
| [`3b069a2e`](https://github.com/NixOS/nixpkgs/commit/3b069a2ef810abb92db95f8ee1162b8fa6d7a9bd) | `bintools-wrapper: add dynamicLinker for riscv`                           |
| [`cbfec29e`](https://github.com/NixOS/nixpkgs/commit/cbfec29e810db7d49221cd4e840df66c9fd9402d) | `moz-phab: use substituteInPlace instead of a patch`                      |
| [`b5608945`](https://github.com/NixOS/nixpkgs/commit/b56089454542ca92634ecdff6c4fe04f723f5f51) | `jpsxdec: init at 1.05`                                                   |
| [`0c0f340c`](https://github.com/NixOS/nixpkgs/commit/0c0f340c22b504ceba6e646c68b9abae5e716eca) | `xorg.xf86videomach64: drop the ancient driver`                           |
| [`fb2b2f8a`](https://github.com/NixOS/nixpkgs/commit/fb2b2f8ab27f872d088b25e25056d7f5e71b3907) | `mani: init at 0.10.0`                                                    |
| [`d8201541`](https://github.com/NixOS/nixpkgs/commit/d820154199fca7630c488742fef7119456b14d50) | `python-language-server: 2021-05-20 -> 2021-09-08, use buildDotnetModule` |
| [`2ea18c6a`](https://github.com/NixOS/nixpkgs/commit/2ea18c6aee200bb3eb44fb0c38c65b655357ea88) | `dotty: use latest JDK`                                                   |
| [`a9ff768b`](https://github.com/NixOS/nixpkgs/commit/a9ff768b992083c1af43ab2ec51cba7bf90a95f7) | `scala_2_13: use latest JDK`                                              |
| [`7cc95a01`](https://github.com/NixOS/nixpkgs/commit/7cc95a01dea4dc2b504f6b9e52009298cc61c5da) | `scala_2_12: use latest JDK`                                              |
| [`a5f19b5f`](https://github.com/NixOS/nixpkgs/commit/a5f19b5fa81bd689bde5dbe0d579be6261ede7dd) | `dico: fix cross-compilation`                                             |
| [`836ba699`](https://github.com/NixOS/nixpkgs/commit/836ba699decfea81318f5219830182884312b812) | `moz-phab: rename patch files`                                            |
| [`ca7a7174`](https://github.com/NixOS/nixpkgs/commit/ca7a71747d195affa8217401e26f8f81dbf02691) | `moz-phab: enable tests, remove pkgs dependency`                          |
| [`34db5494`](https://github.com/NixOS/nixpkgs/commit/34db5494488846b12fda5ddf0aa52edf3c9d2aae) | `python3Packages.glean-sdk: apply patch for process environments`         |
| [`51324da2`](https://github.com/NixOS/nixpkgs/commit/51324da2e02964d9ed2fe24413d138f57abde1fb) | `moz-phab: init at 0.1.99`                                                |
| [`a811dea8`](https://github.com/NixOS/nixpkgs/commit/a811dea815a5494928c46851cc149f91133b0721) | `python3Packages.glean-sdk: init at 42.2.0`                               |
| [`313f74cd`](https://github.com/NixOS/nixpkgs/commit/313f74cd73924b4b7dfc6f519cbc3f4db7c6c13b) | `python3Packages.glean-parser: init at 4.3.1`                             |
| [`634d44ab`](https://github.com/NixOS/nixpkgs/commit/634d44ab55add35de6b12fb8d2b8288c40d50560) | `python3Packages.python-hglib: init at 2.6.1`                             |
| [`d6fe39ec`](https://github.com/NixOS/nixpkgs/commit/d6fe39ecc251362aaa969abf2304b4bdde712b09) | `maintainers: add kvark`                                                  |
| [`27b57106`](https://github.com/NixOS/nixpkgs/commit/27b571067e51450d14387671d20f52b7ec237b22) | `nixos/logrotate: allow hourly frequency`                                 |