### PR TITLE
chore(flake/nixpkgs): `33ef578c` -> `7b031d0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638220705,
-        "narHash": "sha256-HpRLe61ZysTcZcZUB6ZLyBZGQ5e+/NgGKvTE6sDGqaI=",
+        "lastModified": 1638263381,
+        "narHash": "sha256-1rZDxTw74ETuJEjwPfpMgY0sfx8Cv1tRNt3gibol574=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "33ef578c3d4931c73db0f546d9e84fa2ec1fa65d",
+        "rev": "7b031d0d99e8cdaf0b70457c0cb33f16c0c958bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                          |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`9d3d02f9`](https://github.com/NixOS/nixpkgs/commit/9d3d02f9c1272f1845bcd3295a22f4a3acb6326a) | `screen: disable parallel build (#147990)`                                              |
| [`0a989ec7`](https://github.com/NixOS/nixpkgs/commit/0a989ec7caa63aabd47b4aff5aecd5a754cd6cea) | `pantheon.elementary-files: drop filechooser-portal-hardcode-gsettings-for-nixos.patch` |
| [`bc3eea0c`](https://github.com/NixOS/nixpkgs/commit/bc3eea0c68d0be91f7491d22df63f2665ec3e1dc) | `chezmoi: 2.7.4 -> 2.9.0`                                                               |
| [`af21d412`](https://github.com/NixOS/nixpkgs/commit/af21d41260846fb9c9840a75e310e56dfe97d6a3) | `.github/PULL_REQUEST_TEMPLATE.md, CONTRIBUTING.md: 21.11 -> 22.05 (#147977)`           |
| [`94d1b0d5`](https://github.com/NixOS/nixpkgs/commit/94d1b0d54154614c17be5e4c9465f05b45cf851d) | `pantheon.elementary-files: 6.0.4 -> 6.1.0`                                             |
| [`c60adb94`](https://github.com/NixOS/nixpkgs/commit/c60adb947e363a915e057244cfd1c2d61fa22d9a) | `kuma: init at 1.4.0`                                                                   |
| [`c19234d0`](https://github.com/NixOS/nixpkgs/commit/c19234d0dff963a1d49628f648db3d618e8a9c29) | `nixos/tests/installer: increase /boot sizes to 100MB`                                  |
| [`b1faa37c`](https://github.com/NixOS/nixpkgs/commit/b1faa37cdf91a5c06b3eccd2611dc8faa7e6e6ec) | `21.11 Release Notes: fix typos`                                                        |
| [`af92f1c0`](https://github.com/NixOS/nixpkgs/commit/af92f1c0cc2d83361771f7b3f6612219ffca5b3c) | `[21.11] update README.md`                                                              |
| [`6f968f15`](https://github.com/NixOS/nixpkgs/commit/6f968f15727cbf39adbb0d60623f2c11f56eab6b) | `python3Packages.ignite: remove optional pynvml dependency`                             |
| [`34fa1ffb`](https://github.com/NixOS/nixpkgs/commit/34fa1ffbe4140d501bb8d8bfdee5afdf55d50d10) | `Revert ".github/workflows/editorconfig.yml: Don't use GitHub API for PR diff."`        |
| [`4db84ed1`](https://github.com/NixOS/nixpkgs/commit/4db84ed126a16e226c5f1a3f13c7bee92fa0a3a4) | `.github/workflows/editorconfig.yml: Don't use GitHub API for PR diff.`                 |
| [`eefac98f`](https://github.com/NixOS/nixpkgs/commit/eefac98f1a0e3363a57288703fa1961ea554d13e) | `python3Packages.pyvex: fix build for aarch64-linux`                                    |
| [`f30f9c8a`](https://github.com/NixOS/nixpkgs/commit/f30f9c8aa8b4f1a128d08692fe9edbf81079b884) | `frogatto-data: 2020-12-17 -> 2021-11-29`                                               |
| [`cd959d22`](https://github.com/NixOS/nixpkgs/commit/cd959d22517bebb1d767a91c758f626e16337536) | `maigret: init at 0.3.1`                                                                |
| [`1f2c1647`](https://github.com/NixOS/nixpkgs/commit/1f2c16475455fb4a83465e152886d400cb211d30) | `python3Packages.xmind: init at 1.2.0`                                                  |
| [`a75207e9`](https://github.com/NixOS/nixpkgs/commit/a75207e966c24b2c5d9a57e9fbea4dcc70f1742e) | `python3Packages.socid-extractor: init at 0.0.22`                                       |
| [`04a499cd`](https://github.com/NixOS/nixpkgs/commit/04a499cdde91c75ccaac3724827b2636c5e4460e) | `Revert "nixos/hidpi: add xserver dpi"`                                                 |
| [`23188a5f`](https://github.com/NixOS/nixpkgs/commit/23188a5f00dfdc2ff17606fcc5b21531f9569fb2) | `python2Packages.jinja2: fix tests`                                                     |
| [`9c7406a1`](https://github.com/NixOS/nixpkgs/commit/9c7406a10fbd5da521ceb357a53a2d9e169abb72) | `vimPlugins.vim-clap: fix cargoSha256`                                                  |
| [`fa83ed46`](https://github.com/NixOS/nixpkgs/commit/fa83ed462a9bb38939d2676403e5cdfa1438d193) | `python3Packages.nilearn: unbreak tests`                                                |
| [`e8cc900e`](https://github.com/NixOS/nixpkgs/commit/e8cc900eaec34c2b7399678f0cd47c1b0e36a6ef) | `make-disk-image: Make additionalPaths work with Nix 2.4`                               |
| [`958ceefb`](https://github.com/NixOS/nixpkgs/commit/958ceefb3ed3ddb82c10818731747b901044bfac) | `python3Packages.pydicom: add missing setuptools runtime dependency`                    |
| [`4d3ed16d`](https://github.com/NixOS/nixpkgs/commit/4d3ed16dd8182d647abb7735912bdf61088aa2b9) | `fira-code: 5.2 → 6`                                                                    |
| [`cecf41f5`](https://github.com/NixOS/nixpkgs/commit/cecf41f57156a6e613ff2d873bc55ff5d50a42fe) | `python3Packages.autoit-ripper: 1.0.1 -> 1.1.0`                                         |
| [`8191c8e2`](https://github.com/NixOS/nixpkgs/commit/8191c8e226fc158e73358d4951b5f09471753a5a) | `grub2: fix buildPackage bash shebang`                                                  |
| [`76e515cb`](https://github.com/NixOS/nixpkgs/commit/76e515cb267c6de577d14aeab1c2efe7cb2d84a6) | `grub2: switch to release tarball`                                                      |
| [`539811a4`](https://github.com/NixOS/nixpkgs/commit/539811a4d3c680c21a4d493e79048c5aea8fb8bf) | `nixos/gdm: enable nvidiaWayland by default`                                            |
| [`324e9f68`](https://github.com/NixOS/nixpkgs/commit/324e9f686ec39ba5d4a760d957509c52039cec27) | `nixosTests.vengi-tools: init`                                                          |
| [`218f1435`](https://github.com/NixOS/nixpkgs/commit/218f14351463ed26809479410600f2ef136d05b4) | `vengi-tools: init at 0.0.14`                                                           |
| [`3247e757`](https://github.com/NixOS/nixpkgs/commit/3247e757416496ef6a19fb53ffdc4c92c969f39a) | `emacs: resolve wrapper load-path at build time`                                        |