### PR TITLE
refactor: add and correct docstrings and add type aliases for readability

### DIFF
--- a/protoletariat/fdsetgen.py
+++ b/protoletariat/fdsetgen.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import abc
 import fnmatch
-import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -12,12 +11,10 @@ from google.protobuf.descriptor_pb2 import FileDescriptorSet
 
 from .rewrite import ASTImportRewriter, build_rewrites
 
-_PROTO_SUFFIX_PATTERN = re.compile(r"^(.+)\.proto$")
-
 
 def _remove_proto_suffix(name: str) -> str:
     """Remove the `.proto` suffix from `name`."""
-    return _PROTO_SUFFIX_PATTERN.sub(r"\1", name)
+    return str(Path(name).with_suffix("")) if name.endswith(".proto") else name
 
 
 def _should_ignore(fd_name: str, patterns: Sequence[str]) -> bool:

--- a/protoletariat/fdsetgen.py
+++ b/protoletariat/fdsetgen.py
@@ -93,11 +93,11 @@ class Protoc(FileDescriptorSetGenerator):
     def __init__(
         self,
         protoc_path: str,
-        paths: Iterable[Path],
+        proto_files: Iterable[Path],
         proto_paths: Iterable[Path],
     ) -> None:
         super().__init__(protoc_path)
-        self.paths = list(paths)
+        self.proto_files = list(proto_files)
         self.proto_paths = list(proto_paths)
 
     def generate_file_descriptor_set_bytes(self) -> bytes:
@@ -109,7 +109,7 @@ class Protoc(FileDescriptorSetGenerator):
                     "--include_imports",
                     f"--descriptor_set_out={filename}",
                     *map("--proto_path={}".format, self.proto_paths),
-                    *map(str, self.paths),
+                    *map(str, self.proto_files),
                 ]
             )
 

--- a/protoletariat/fdsetgen.py
+++ b/protoletariat/fdsetgen.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import fnmatch
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -11,10 +12,12 @@ from google.protobuf.descriptor_pb2 import FileDescriptorSet
 
 from .rewrite import ASTImportRewriter, build_rewrites
 
+_PROTO_SUFFIX_PATTERN = re.compile(r"^(.+)\.proto$")
+
 
 def _remove_proto_suffix(name: str) -> str:
     """Remove the `.proto` suffix from `name`."""
-    return str(Path(name).with_suffix("")) if name.endswith(".proto") else name
+    return _PROTO_SUFFIX_PATTERN.sub(r"\1", name)
 
 
 def _should_ignore(fd_name: str, patterns: Sequence[str]) -> bool:

--- a/protoletariat/fdsetgen.py
+++ b/protoletariat/fdsetgen.py
@@ -23,6 +23,8 @@ def _should_ignore(fd_name: str, patterns: Sequence[str]) -> bool:
 
 
 class FileDescriptorSetGenerator(abc.ABC):
+    """Base class that implements fixing imports."""
+
     def __init__(self, fdset_generator_binary: str) -> None:
         self.fdset_generator_binary = fdset_generator_binary
 
@@ -38,6 +40,7 @@ class FileDescriptorSetGenerator(abc.ABC):
         module_suffixes: Sequence[str],
         exclude_imports_glob: Sequence[str],
     ) -> None:
+        """Fix imports from protoc/buf generated code."""
         rewriters = {}
         fdset = FileDescriptorSet.FromString(self.generate_file_descriptor_set_bytes())
 


### PR DESCRIPTION
- refactor: remove typed-ast usage
- refactor: remove use of re in favor of Path
- refactor: add and correct docstrings and add type aliases for readability
