### PR TITLE
fix: ensure every path is decoded using os.fsdecode

### DIFF
--- a/protoletariat/fdsetgen.py
+++ b/protoletariat/fdsetgen.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import abc
 import fnmatch
+import os
 import re
 import subprocess
 import tempfile
-import os
 from pathlib import Path
 from typing import Callable, Iterable, Sequence
 
@@ -14,6 +14,7 @@ from google.protobuf.descriptor_pb2 import FileDescriptorSet
 from .rewrite import ASTImportRewriter, build_rewrites
 
 _PROTO_SUFFIX_PATTERN = re.compile(r"^(.+)\.proto$")
+
 
 def _remove_proto_suffix(name: str) -> str:
     """Remove the `.proto` suffix from `name`."""


### PR DESCRIPTION
I'm using Click 7.1.2. For some reason, the input file paths were `bytes` instead of `str`, causing lots of errors when I tried to run `protol`.

This PR fixed the problem for me. It's probably a safe thing to merge, and it guards against other strange Click incompatibilities.

In case it matters, here's how I was invoking `protol`:

https://github.com/shawwn/tensorflow-checkpoint-reader/blob/c8a77dc82c88f52971f11a96e59d5ace7b595611/build.sh#L15-L16