### PR TITLE
chore(flake/nixpkgs): `58371472` -> `b0819012`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638437181,
-        "narHash": "sha256-Y9H127RyfXNTHs1E1DrUzQ0aLEw4fmZ40sI3j5lxoHQ=",
+        "lastModified": 1638480607,
+        "narHash": "sha256-tv+SXCgsuBGtuHa/wjPtCDGzfxk6PUT30F9mpX/FWaE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58371472fe78c979964df42542e9db0e74c5c2bd",
+        "rev": "b0819012c4d3bcbe68024d6da3576a7e5607606d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`b0819012`](https://github.com/NixOS/nixpkgs/commit/b0819012c4d3bcbe68024d6da3576a7e5607606d) | `gh: 2.2.0 -> 2.3.0`                                                       |
| [`ea90c516`](https://github.com/NixOS/nixpkgs/commit/ea90c516e79a9231acef34e369c544836242ef34) | `nixos/shairport-sync: add firewall rules`                                 |
| [`34d4676e`](https://github.com/NixOS/nixpkgs/commit/34d4676e9d9d8778523235e52b9e9c5bd1f8d6d9) | `nixos/doc/manual/release-notes/rl-2111: fix multiple option links`        |
| [`82ee5f20`](https://github.com/NixOS/nixpkgs/commit/82ee5f20c7a3881a00257978f98b2e2c4622330c) | `pop-icon-theme: restrict platforms to linux`                              |
| [`d1da5658`](https://github.com/NixOS/nixpkgs/commit/d1da5658a64eae7b22d87b8ac928310a59ab3196) | `nixos/doc/manual/release-notes/rl-2111: move highlights introduction`     |
| [`7bb2729d`](https://github.com/NixOS/nixpkgs/commit/7bb2729d0a642677442e2f4733152d676c21bd76) | `diffoscope: 192 -> 194`                                                   |
| [`fa06cf55`](https://github.com/NixOS/nixpkgs/commit/fa06cf556e84ed7991ba78d92a4093a8dc0d5056) | `ec2-amis: add release 21.11`                                              |
| [`2ae84eb5`](https://github.com/NixOS/nixpkgs/commit/2ae84eb551220de68abf5ac55a0d95c1cefc69da) | `pop-icon-theme: remove some dependencies`                                 |
| [`d0cb9036`](https://github.com/NixOS/nixpkgs/commit/d0cb903609e044bfec9815561ba47b4c5c9f1517) | `strace: 5.14 -> 5.15`                                                     |
| [`8580bda6`](https://github.com/NixOS/nixpkgs/commit/8580bda6863fa0cf2f926b650938fc422184efd6) | `libcpuid: fix cross compilation to NetBSD`                                |
| [`b5b4a6ac`](https://github.com/NixOS/nixpkgs/commit/b5b4a6ac4fab75aa857c16fe7c27647d8215fd55) | `mathematica: Install desktop items (#147641)`                             |
| [`a810f767`](https://github.com/NixOS/nixpkgs/commit/a810f7676c1b6e23b317b5f792145de3147faea3) | `snappy: add patch to re-enable RTTI`                                      |
| [`d24027a6`](https://github.com/NixOS/nixpkgs/commit/d24027a6846d64d081f5a1c74aa02c49bf44d288) | `coqPackages.coqprime: 8.12 → 8.14.1`                                      |
| [`1304435f`](https://github.com/NixOS/nixpkgs/commit/1304435f48c4b07f2886f240b674a38069f94758) | `i3: 4.20 -> 4.20.1 (#148253)`                                             |
| [`160682f3`](https://github.com/NixOS/nixpkgs/commit/160682f3487ac9f2ccbd8b51d98ae43610e0c2e0) | `terraform-providers: sort`                                                |
| [`fbdfa323`](https://github.com/NixOS/nixpkgs/commit/fbdfa32356a8275824db809636eeb46c4da3960f) | `terraform-providers.vault: 3.0.0 -> 3.0.1`                                |
| [`d871541f`](https://github.com/NixOS/nixpkgs/commit/d871541f064d33666e23d8128a01c066b45e5837) | `terraform-providers.nomad: 1.4.15 -> 1.4.16`                              |
| [`d5a8b6e0`](https://github.com/NixOS/nixpkgs/commit/d5a8b6e06353f72007d68176d4d23ab1c49e50f0) | `terraform-providers.kubernetes: 2.6.1 -> 2.7.0`                           |
| [`5dd8c34e`](https://github.com/NixOS/nixpkgs/commit/5dd8c34e3b96bae34c5ab93323e4b7968a277d85) | `terraform-providers.github: 4.18.0 -> 4.18.2`                             |
| [`38f9e483`](https://github.com/NixOS/nixpkgs/commit/38f9e483a5b60452c29d9ffc5272b6130184e414) | `zerotierone: 1.8.3 -> 1.8.4`                                              |
| [`e5690827`](https://github.com/NixOS/nixpkgs/commit/e5690827b5b6fc5aef4c8e135653ff507412b2d8) | `python3Packages.pyarrow: fix darwin build for when a build flag is false` |
| [`2d024825`](https://github.com/NixOS/nixpkgs/commit/2d024825827bfb95576938b01bc7f7a4bfd5f330) | `clipman: 1.6.0 -> 1.6.1`                                                  |
| [`f524d705`](https://github.com/NixOS/nixpkgs/commit/f524d70519b45e79c4bcee5055e6f5710f783779) | `mcomix: fix invalid .desktop icon name`                                   |
| [`ba798538`](https://github.com/NixOS/nixpkgs/commit/ba798538d076f5dea9e5f8bafdec0384fef9b1d6) | `terraform-providers.dhall: init at 0.0.1`                                 |
| [`28731a2d`](https://github.com/NixOS/nixpkgs/commit/28731a2d43e7771259a3ba63a8afbe8b2a43ceb9) | `csvdiff: Init at 1.4.0`                                                   |
| [`56ea0c93`](https://github.com/NixOS/nixpkgs/commit/56ea0c9308e084acdf59b46721619cc847ae8b06) | `qemu: fix darwin build`                                                   |
| [`82470faf`](https://github.com/NixOS/nixpkgs/commit/82470faf7dab753c113ccdb76abb5b8a1159a526) | `nixpkgs-review: 2.6.3 -> 2.6.4`                                           |
| [`089fdb8d`](https://github.com/NixOS/nixpkgs/commit/089fdb8dfaa3070b37c66fcf5b1445f343255a05) | `libbpf: 0.5.0 -> 0.6.0`                                                   |
| [`932ab304`](https://github.com/NixOS/nixpkgs/commit/932ab304f0b8e3241c1311b9b731d3d330291715) | `emacsPackages.orgPackages: deprecated`                                    |
| [`41304a95`](https://github.com/NixOS/nixpkgs/commit/41304a957cf8bf38c3f0ecfc356b1abfd1448e85) | `lldpd: 1.0.11 -> 1.0.13`                                                  |
| [`9487f3ae`](https://github.com/NixOS/nixpkgs/commit/9487f3aeba776f7f28b1befd6c0f5a17982cc531) | `pop-icon-theme: 2020-03-04 -> 2021-11-17`                                 |
| [`552f9ca7`](https://github.com/NixOS/nixpkgs/commit/552f9ca7652861e6dcc6ab2c0ba80d3c68bdab1e) | `flat-remix-icon-theme: 20200710 -> 20211106`                              |
| [`bf8af0b8`](https://github.com/NixOS/nixpkgs/commit/bf8af0b8d454d6ec9609a3295cc8e26ffbf671c7) | `pop-gtk-theme: 2020-06-30 -> 2021-08-19`                                  |
| [`d86329b7`](https://github.com/NixOS/nixpkgs/commit/d86329b7cd29d1fb6c261d6a022a4de9dacc942d) | `flat-remix-gtk: 20201129 -> 20211130`                                     |
| [`e57ef456`](https://github.com/NixOS/nixpkgs/commit/e57ef4569e04e2db61a2f1057491dae52079b338) | `starship: build with notification support`                                |
| [`b9e6351d`](https://github.com/NixOS/nixpkgs/commit/b9e6351d30996e660dc5deceb5810535b21d0345) | `maintainers: rename legendofmiracles to lom`                              |
| [`3b2742e7`](https://github.com/NixOS/nixpkgs/commit/3b2742e7bb3c262301481345288e35cbf7b4a406) | `asmrepl: init at 1.0.2`                                                   |
| [`97d8492a`](https://github.com/NixOS/nixpkgs/commit/97d8492ac54aa9f22c9469e274dbc5345e6fbc1c) | `sumneko-lua-language-server: Add darwin support`                          |
| [`06473a1c`](https://github.com/NixOS/nixpkgs/commit/06473a1c6faf8c085449550d2bb7192cc070886b) | `lunatic: 0.6.2 -> 0.7.0`                                                  |
| [`b1cbba2c`](https://github.com/NixOS/nixpkgs/commit/b1cbba2cc9822f3200c5f01160ab5679ecd4fbc5) | `vimPlugins: update`                                                       |
| [`be53d7d2`](https://github.com/NixOS/nixpkgs/commit/be53d7d2d68ffedd31569b3b697d25a9ca335dc1) | `vimPlugins.nvim-treesitter{,-textobjects}: use default branch`            |
| [`4a49525f`](https://github.com/NixOS/nixpkgs/commit/4a49525fa0169c971ff46459deb8d9b5102efa76) | `jtc: 1.75d -> 1.76`                                                       |
| [`373ec365`](https://github.com/NixOS/nixpkgs/commit/373ec365bdb85d68a823a084974216f95c146b4d) | `rqbit: 2.1.2 -> 2.1.3`                                                    |
| [`0fd4de2a`](https://github.com/NixOS/nixpkgs/commit/0fd4de2ae21bc4a1a70e1d2349b64578794852fc) | `plan9port: add DarwinTools to buildInputs on darwin`                      |
| [`1c725641`](https://github.com/NixOS/nixpkgs/commit/1c725641c94d7d939d949b74804063de41535336) | `evcxr: 0.11.0 -> 0.12.0`                                                  |
| [`f146c929`](https://github.com/NixOS/nixpkgs/commit/f146c92955309ecc4d8be5c29be6028b97557703) | `gitaly: use custom libgit2 commit`                                        |
| [`ce91a90d`](https://github.com/NixOS/nixpkgs/commit/ce91a90d7a67b05a7e179c9b555a9c2dadbeb688) | `roundcube: 1.5.0 -> 1.5.1`                                                |
| [`e2668f6a`](https://github.com/NixOS/nixpkgs/commit/e2668f6a7b9ddf2852d85720ad78d019c7379c5c) | `gitlab: 14.4.2 -> 14.5.0`                                                 |
| [`c67c811f`](https://github.com/NixOS/nixpkgs/commit/c67c811fa655a821c477336c3041c76f829ee1b5) | `schismtracker: 20210525 -> 20211116`                                      |
| [`b71ed45c`](https://github.com/NixOS/nixpkgs/commit/b71ed45cfc402ee498b973dc919e8bcf433deeea) | `wl-mirror: init at 0.5.0`                                                 |
| [`e0eb89f3`](https://github.com/NixOS/nixpkgs/commit/e0eb89f3916ae5b5e8e3c45909df8c82383b622a) | `element-desktop: 1.9.4 -> 1.9.5`                                          |
| [`4c053bd1`](https://github.com/NixOS/nixpkgs/commit/4c053bd1f8e7c0d571f435a06a37f473bd44ddde) | `gitkraken: 8.1.0 -> 8.1.1`                                                |
| [`92f00038`](https://github.com/NixOS/nixpkgs/commit/92f000385a30165c73dd63ec969c296a60f76af2) | `python3Packages.django-rq: 2.4.1 -> 2.5.0`                                |
| [`742fddd5`](https://github.com/NixOS/nixpkgs/commit/742fddd514417ac98979089a18b17de420d3e5a8) | `cloudmonkey: 6.1.0 -> 6.2.0`                                              |
| [`49d5bc25`](https://github.com/NixOS/nixpkgs/commit/49d5bc254bec5b50532a92c4376d12de749a0511) | `mstflint: 4.14.0-3 -> 4.17.0-1`                                           |