### PR TITLE
chore(flake/nixpkgs): `f9a1652a` -> `7f6a2d56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638565206,
-        "narHash": "sha256-5z7RBRw0qh3REJieanK3PkMHl0EuzZr2efZqAz44Bjg=",
+        "lastModified": 1638609838,
+        "narHash": "sha256-RPF0nKZwaOp1E8LrW4q1Hfza5g7zN9+TA9oOW5urC80=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9a1652a858329525c143450db2474ef439cf6c1",
+        "rev": "7f6a2d5663d0127d4aa48d2e839fd04aaa1d93e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`7f6a2d56`](https://github.com/NixOS/nixpkgs/commit/7f6a2d5663d0127d4aa48d2e839fd04aaa1d93e7) | `oci-containers: fix imageFile example`                                     |
| [`deef812a`](https://github.com/NixOS/nixpkgs/commit/deef812ae8b600fd6f70d06eddcb325b79e267dd) | `frama-c: 23.1 (Vanadium) → 24.0 (Chromium)`                                |
| [`652b351d`](https://github.com/NixOS/nixpkgs/commit/652b351d3e03e3bd437a6f0fc0a600abef0ee4c7) | `flat-remix-gnome: 20211113 -> 20211202.`                                   |
| [`bb9bd465`](https://github.com/NixOS/nixpkgs/commit/bb9bd465b625bfc971908c5d3d84ce517e1c0691) | `go_1_17: 1.17.3 -> 1.17.4`                                                 |
| [`f01e9125`](https://github.com/NixOS/nixpkgs/commit/f01e91259921d0e3308d9586f4180c5b927ca12e) | `scaleway-cli: 1.20 -> 2.4.0`                                               |
| [`0d8cbc4f`](https://github.com/NixOS/nixpkgs/commit/0d8cbc4fd4c8ca52440a1f51a1cc0b11de8ed7ed) | `rmapi: 0.0.17 -> 0.0.18 (#148531)`                                         |
| [`de5ab388`](https://github.com/NixOS/nixpkgs/commit/de5ab3881e4868dcfa9f75723bd035ce99cb0751) | `flashrom: build with default gcc`                                          |
| [`9118fde4`](https://github.com/NixOS/nixpkgs/commit/9118fde4b08fb822861b2922007628c6d59f2286) | `scrypt: fix build on aarch64-darwin`                                       |
| [`fd481c68`](https://github.com/NixOS/nixpkgs/commit/fd481c684ce079c79ce074337161f7ff1bb84231) | `scrcpy: 1.20 -> 1.21`                                                      |
| [`23315789`](https://github.com/NixOS/nixpkgs/commit/23315789cfc5250f9bdf80a8b21e130f8a096a6b) | `keepass: 2.48.1 -> 2.49`                                                   |
| [`b5a44bdc`](https://github.com/NixOS/nixpkgs/commit/b5a44bdcbd667a1a72ac5c66b16c6ddfbc86e22d) | `keepass: stop saving config to /nix/store`                                 |
| [`1938cc6e`](https://github.com/NixOS/nixpkgs/commit/1938cc6e5582788407237bfe8b607cd1092853c4) | `gitflow: embed path to coreutils into the wrapper`                         |
| [`719beec2`](https://github.com/NixOS/nixpkgs/commit/719beec27a0bee55b6ee78987aedeadf1d08026d) | `electrum-ltc: 3.3.8.1 -> 4.0.9.3`                                          |
| [`4034242a`](https://github.com/NixOS/nixpkgs/commit/4034242a8ab9e15da5db91a2d5928d0868c38bcc) | `amdgpu-pro: fix homepage`                                                  |
| [`cd4005ff`](https://github.com/NixOS/nixpkgs/commit/cd4005ff32fa438078bb1850ad018291b0a09e4a) | `_0x0: remove`                                                              |
| [`60422ba2`](https://github.com/NixOS/nixpkgs/commit/60422ba2ead07583dba311e9597f07789fe061d6) | `nixos/test-driver: add 10ms delay to send_key`                             |
| [`652e492d`](https://github.com/NixOS/nixpkgs/commit/652e492d29f74e2988ec42a71a66c60f47285ac7) | `koreader: 2021.10.1 -> 2021.11`                                            |
| [`3132edd3`](https://github.com/NixOS/nixpkgs/commit/3132edd34bb7ad2784eaa947c7db1336e55f11c3) | `theharvester: 4.0.2 -> 4.0.3`                                              |
| [`5f9d59a1`](https://github.com/NixOS/nixpkgs/commit/5f9d59a1aa9dd7c31fb754e2b431bce4436163bf) | `exploitdb: 2021-11-27 -> 2021-12-02`                                       |
| [`ee08487d`](https://github.com/NixOS/nixpkgs/commit/ee08487d7bef9f2e7010c393e683aca0dd9f7c0d) | `metasploit: 6.1.16 -> 6.1.17`                                              |
| [`c2976dee`](https://github.com/NixOS/nixpkgs/commit/c2976dee91fe1b7136b3ae6ce497959a66cdd26c) | `goaccess: 1.5.2 -> 1.5.3`                                                  |
| [`9b44103e`](https://github.com/NixOS/nixpkgs/commit/9b44103ef274016bb141f230752f20d2841d46ed) | `natscli: 0.0.26 -> 0.0.28`                                                 |
| [`145cc3ae`](https://github.com/NixOS/nixpkgs/commit/145cc3ae032004c7cac18be335e5903961e68904) | `python3Packages.ge25519: relax constraints`                                |
| [`cf0f42ce`](https://github.com/NixOS/nixpkgs/commit/cf0f42ce9a452f1a192bdb299803655510f5194f) | `python3Packages.fe25519: relax constraints`                                |
| [`838dbde1`](https://github.com/NixOS/nixpkgs/commit/838dbde1ab8d0c645d61b1725f2439055fc3df1e) | `python3Packages.fountains: relax bitlist constraint`                       |
| [`677e4599`](https://github.com/NixOS/nixpkgs/commit/677e459931fa414a2066e9dabe237177041e85d3) | `python3Packages.qcs-api-client: 0.20.4 -> 0.20.5`                          |
| [`3c7bd36c`](https://github.com/NixOS/nixpkgs/commit/3c7bd36c553a9abd77f9733f838ad020497226ed) | `python3Packages.bitlist: 0.5.1 -> 0.6.0`                                   |
| [`b1c9bf9d`](https://github.com/NixOS/nixpkgs/commit/b1c9bf9d6b780527b57ea661cd6ff46a8bf97fe3) | `python3Packages.parts: 1.1.2 -> 1.2.0`                                     |
| [`cf7ea5b6`](https://github.com/NixOS/nixpkgs/commit/cf7ea5b6b519e461176ebaed98cf1c080f862271) | `globalprotect-openconnect: use ver rev instead of commit & correct sha256` |
| [`ee36beaf`](https://github.com/NixOS/nixpkgs/commit/ee36beaf0878a9d57f2f7821d4342d7fabc7d3d0) | `glitter: 1.5.8 -> 1.5.9`                                                   |
| [`8da44bcd`](https://github.com/NixOS/nixpkgs/commit/8da44bcdd1895f5233e1b78580c7d548f0195cc8) | `glitter: 1.5.7 -> 1.5.8`                                                   |
| [`53f32adc`](https://github.com/NixOS/nixpkgs/commit/53f32adc65b9124ba6f48e1924f5ec962650b4c3) | `cp2k: build with elpa`                                                     |
| [`1c20debb`](https://github.com/NixOS/nixpkgs/commit/1c20debb1a2b83cb896fe49dc01ebca25b50967c) | `elpa: init at 2021.05.002_bugfix`                                          |
| [`95d7a591`](https://github.com/NixOS/nixpkgs/commit/95d7a591ea99e30a7baaf41ccc1a883bc9c1370d) | `glfw: patch linkage with X11`                                              |
| [`56391a5c`](https://github.com/NixOS/nixpkgs/commit/56391a5c5766d58b4df3ccf0a7363454498cae7e) | `glfw: 3.3.4 -> 3.3.5`                                                      |
| [`a6246157`](https://github.com/NixOS/nixpkgs/commit/a624615754cc1adeeaa7f2b2943f69efb2725be0) | `root: Ignore default JetBrains IDEA module configuration`                  |