### PR TITLE
chore(flake/nixpkgs): `7f6a2d56` -> `11e5bcc9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638609838,
-        "narHash": "sha256-RPF0nKZwaOp1E8LrW4q1Hfza5g7zN9+TA9oOW5urC80=",
+        "lastModified": 1638653945,
+        "narHash": "sha256-kPi8BK3UmIskP1Z2sG6KI0QEXBd/SHu72dpSDOL0ZEw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7f6a2d5663d0127d4aa48d2e839fd04aaa1d93e7",
+        "rev": "11e5bcc974c36310ee5c38e1cd7eff4cfed04778",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`96e01b7e`](https://github.com/NixOS/nixpkgs/commit/96e01b7e1689d3ee9d2a674a99aa9702e808f5f3) | `gnomeExtensions: fix ddterm`                                                       |
| [`44b84602`](https://github.com/NixOS/nixpkgs/commit/44b84602c940f4693789501f42f05d007c463031) | `python3Packages.myfitnesspal: 1.16.4 -> 1.16.5`                                    |
| [`5f8babdd`](https://github.com/NixOS/nixpkgs/commit/5f8babdd259d68ff8052dfc8d650ebdf9cc3bd75) | `doc beam section: Takle TODO (#148624)`                                            |
| [`3f996208`](https://github.com/NixOS/nixpkgs/commit/3f9962083619d512b754256ad6dfa8f6a8c3a659) | `python3Packages.notebook: disable networking tests on darwin`                      |
| [`b37d18e7`](https://github.com/NixOS/nixpkgs/commit/b37d18e7316edf92390bd4533f67a9cfd0ad27d8) | `cosign: 1.3.0 -> 1.3.1`                                                            |
| [`60252466`](https://github.com/NixOS/nixpkgs/commit/60252466babdc28e647f6d7fb4544233cadacf33) | `vault-bin: set dontStrip for darwin`                                               |
| [`1a119b22`](https://github.com/NixOS/nixpkgs/commit/1a119b223c8258ede92ef197b3a8c486b54b4843) | `vault{,bin}: 1.8.4 -> 1.9.0`                                                       |
| [`4481ef61`](https://github.com/NixOS/nixpkgs/commit/4481ef61e6a571fcbf6ecaa22fe0b5676f9d75f0) | `qradiolink: 0.8.5-2 -> 0.8.6-2`                                                    |
| [`810515f8`](https://github.com/NixOS/nixpkgs/commit/810515f8766eaefd61db358d54849c9d6cd76287) | `lilo: make sure scripts and manpages are installed properly`                       |
| [`d6a4500f`](https://github.com/NixOS/nixpkgs/commit/d6a4500f88725c24b82f6f86fb3129ed0561800c) | `nixos/ddclient: support all special characters in password`                        |
| [`9c1fc9a0`](https://github.com/NixOS/nixpkgs/commit/9c1fc9a0180dd5e9cd304f8d62c935513ab6eeb6) | `aerc: 0.5.2 -> 0.6.0`                                                              |
| [`16e55eac`](https://github.com/NixOS/nixpkgs/commit/16e55eac065d8db933a5b203fbf55f840b6823d4) | `tev: remove myself as maintainer`                                                  |
| [`3b3494ec`](https://github.com/NixOS/nixpkgs/commit/3b3494eca289a5e902e78f116fdd13c0a862ed52) | `tev: 1.17 -> 1.19`                                                                 |
| [`ddda5f28`](https://github.com/NixOS/nixpkgs/commit/ddda5f28e1f85e0f056996dbf2d2d7fa3718da0f) | `dockerTools: Keep fakechroot disabled by default`                                  |
| [`0e9bc9ff`](https://github.com/NixOS/nixpkgs/commit/0e9bc9ffd107c288571af4e3d4a9c2a6b64cf505) | `dockerTools: Add fakechroot to fakeRootCommands`                                   |
| [`11a5b0b8`](https://github.com/NixOS/nixpkgs/commit/11a5b0b895efcfa4b1ad4ee762caa2e0a0fc3e20) | `python3Packages.autopep8: 1.5.7 -> 1.6.0`                                          |
| [`dd200194`](https://github.com/NixOS/nixpkgs/commit/dd2001942d47452e7207f1144d8b59f58ce9d32d) | `sgx-sdk: enable parallel building`                                                 |
| [`8a713779`](https://github.com/NixOS/nixpkgs/commit/8a713779ee57877504e67f03d92905d3107e349d) | `sgx-sdk: remove superfluous `ncurses` input`                                       |
| [`ca82a582`](https://github.com/NixOS/nixpkgs/commit/ca82a582d9ee3ba9f28d55e283dbf85d1148a0a8) | `nixos/rtsp-simple-server: init`                                                    |
| [`b4642eee`](https://github.com/NixOS/nixpkgs/commit/b4642eee27b9e0803d420a709cb1b9b5e2ff32eb) | `rtsp-simple-server: 0.17.3 -> 0.17.8`                                              |
| [`05d223f5`](https://github.com/NixOS/nixpkgs/commit/05d223f53e416f734bc8796c3690aef70402a9b3) | `rubyPackages.zookeeper: drop outdated patch`                                       |
| [`8e29102c`](https://github.com/NixOS/nixpkgs/commit/8e29102ccbdcd42804f9b0f91e3981d9662af8c4) | `statix: 0.4.1 -> 0.4.2`                                                            |
| [`59214cc0`](https://github.com/NixOS/nixpkgs/commit/59214cc08fe3b5d9db5231aa3bcebf1fa65ce50c) | `python3Packages.adblock: 0.5.0 -> 0.5.1`                                           |
| [`e45a748e`](https://github.com/NixOS/nixpkgs/commit/e45a748e7722a78ff16948e918df3e7dc2707b0e) | `@prisma/language-server: init at 3.6.0`                                            |
| [`d7ffe95f`](https://github.com/NixOS/nixpkgs/commit/d7ffe95f6437e32a2188dde24cab593b8f50be8f) | `python3Packages.jupytext: 1.11.2 -> 1.13.2`                                        |
| [`4fc9618a`](https://github.com/NixOS/nixpkgs/commit/4fc9618a98f9d76230e2e2d394d7fff3d7e6a941) | `python3Packages.mdit-py-plugins: 0.2.8 -> 0.3.0`                                   |
| [`6041dd24`](https://github.com/NixOS/nixpkgs/commit/6041dd24127144482f1bea7a131ef3d609b7d0e9) | `python3Packages.markdown-it-py: 1.1.0 -> 2.0.0`                                    |
| [`baac79cc`](https://github.com/NixOS/nixpkgs/commit/baac79cc39b0e3deddea678d52e21f7d47a4ed87) | `python3Packages.mdurl: init at 0.1.0`                                              |
| [`45528dec`](https://github.com/NixOS/nixpkgs/commit/45528dec8ba3cae82561010081ad594cb506b9ee) | `python3Packages.mdformat: 0.7.10 -> 0.7.11`                                        |
| [`455e4356`](https://github.com/NixOS/nixpkgs/commit/455e4356a3c4d2b8ce485e8518979394c6f3a600) | `gospider: 1.1.5 -> 1.1.6`                                                          |
| [`10683fe1`](https://github.com/NixOS/nixpkgs/commit/10683fe1c493259fe63e09ca9d1a14c23507c2c9) | `gdu: 5.11.0 -> 5.12.0`                                                             |
| [`d112a336`](https://github.com/NixOS/nixpkgs/commit/d112a3363a3c551f6abee9b080b4f9bc9588300e) | `python3Packages.cssselect2: remove superfluous dependencies`                       |
| [`a7f089b9`](https://github.com/NixOS/nixpkgs/commit/a7f089b9bac627627ea28300fd046467cf7256a0) | `pgformatter: 5.1 -> 5.2`                                                           |
| [`2f12f30f`](https://github.com/NixOS/nixpkgs/commit/2f12f30f005155e1076034abaeed2d1a3d6fea7d) | `nixos/plasma5: Split common Plasma config for Mobile from Desktop`                 |
| [`7f4324c6`](https://github.com/NixOS/nixpkgs/commit/7f4324c64eb03efb338c731613dd00325e56e173) | `nixos/plasma5: Add suggested plasma mobile apps`                                   |
| [`7df34e11`](https://github.com/NixOS/nixpkgs/commit/7df34e11456ac3c86495e15975a3b37f7d1d2430) | `nixos/plasma5: configuration for plasma mobile`                                    |
| [`13a03fb2`](https://github.com/NixOS/nixpkgs/commit/13a03fb289a5a83a0d042de51fefe27ee35a9ac1) | `nixos/plasma5: Add maliit-keyboard to plasma mobile session`                       |
| [`b41923c1`](https://github.com/NixOS/nixpkgs/commit/b41923c1ca353d750cc2cf7bcec9c0c3ca4e3b2f) | `nixos/plasma5: configuration for plasma mobile`                                    |
| [`da6a3943`](https://github.com/NixOS/nixpkgs/commit/da6a39436b20d9aecbb32b863ac8a97a2e8f4941) | `nixos/plasma5: Add mobile.enable option for plasma`                                |
| [`fde4f481`](https://github.com/NixOS/nixpkgs/commit/fde4f481d992cd1b064844b70905814880aa6627) | `nixos/plasma5: Make kwinrc/kdeglobals internally configurable`                     |
| [`b9a46149`](https://github.com/NixOS/nixpkgs/commit/b9a461490a3ed00b2c9c5692a1cceb9aa69f07a4) | `maliit-keyboard: Init at 2.0.0`                                                    |
| [`11f6a19d`](https://github.com/NixOS/nixpkgs/commit/11f6a19dcf31177778a36eb52fb5bc95ecba3874) | `maliit-framework: init at 2.0.0`                                                   |
| [`01d45ee6`](https://github.com/NixOS/nixpkgs/commit/01d45ee673e8eac14e8cfc58d432a2a97d9f94b3) | `taplo-cli: 0.4.1 -> 0.5.0`                                                         |
| [`6a9d3034`](https://github.com/NixOS/nixpkgs/commit/6a9d3034896182a2c03c42b530fd7cbe97ce3661) | `plasma-nano: Init at 5.23.3`                                                       |
| [`3ed0e42e`](https://github.com/NixOS/nixpkgs/commit/3ed0e42e0f8ec3ee78ea4e22b3722335459ea675) | `plasma-phone-components: Init at 5.23.3`                                           |
| [`25d6118d`](https://github.com/NixOS/nixpkgs/commit/25d6118dbdc01e0f7115ee2857118c184bb36faa) | `delta: 0.10.2 -> 0.10.3`                                                           |
| [`b368c0dc`](https://github.com/NixOS/nixpkgs/commit/b368c0dcca399ed01732a965965962c6df5d9223) | `plasma-settings: init at 21.08`                                                    |
| [`17e3b754`](https://github.com/NixOS/nixpkgs/commit/17e3b75414e19abe428f7bbcfe5d465ba8cd86ca) | `picard-tools: 2.26.4 -> 2.26.6`                                                    |
| [`d205f7e6`](https://github.com/NixOS/nixpkgs/commit/d205f7e6af01f522d55acf133e362a8ad32b9682) | `gnomeExtensions.x11-gestures: can't find Touchegg`                                 |
| [`05e82bfd`](https://github.com/NixOS/nixpkgs/commit/05e82bfdc2ecf6d0b0a657a15a12d64138b65c17) | `gnomeExtensions.x11-gestures:  can't find Touchegg`                                |
| [`7cdb554c`](https://github.com/NixOS/nixpkgs/commit/7cdb554cb9279c5d6abcb35a4bc7c4aa0215985c) | `piping-server-rust: 0.10.1 -> 0.10.2`                                              |
| [`e0efddfc`](https://github.com/NixOS/nixpkgs/commit/e0efddfc53e472cc346a0f903070ac71d46ca409) | `go-task: 3.9.1 -> 3.9.2`                                                           |
| [`c0f4b20d`](https://github.com/NixOS/nixpkgs/commit/c0f4b20db7e8f39f60da8c09686f013d955bbee1) | `nextcloud23: init at 23.0.0`                                                       |
| [`6020c755`](https://github.com/NixOS/nixpkgs/commit/6020c755ed9c3b56629cbe1f6576f0785976051a) | `clickhouse-backup: init at 1.2.2`                                                  |
| [`05f3d0b5`](https://github.com/NixOS/nixpkgs/commit/05f3d0b58761f37e26ad4a813536e4467c5130c9) | `grafana: 8.2.5 -> 8.3.0`                                                           |
| [`565ceb25`](https://github.com/NixOS/nixpkgs/commit/565ceb25962760ec1d77217ff4ff9ea13a94b8f4) | `CODEOWNERS: Add entries for GNOME`                                                 |
| [`d791ddbb`](https://github.com/NixOS/nixpkgs/commit/d791ddbb5ea5aa1c467cf0aedeb62cbf846f007a) | `CODEOWNERS: Update teams`                                                          |
| [`50d7facb`](https://github.com/NixOS/nixpkgs/commit/50d7facb9b15f61f67455925211dcfda9587e145) | `pocket-casts: switch to electron_14`                                               |
| [`df22f8ee`](https://github.com/NixOS/nixpkgs/commit/df22f8eeae0ae77b41ad5e6f54c3b8a136f4eaf5) | `binance: switch to electron_13`                                                    |
| [`77fd7e9d`](https://github.com/NixOS/nixpkgs/commit/77fd7e9d37f27a50e396cc5051b3eeb395b604ce) | `whalebird: switch to electron_14`                                                  |
| [`58546a5f`](https://github.com/NixOS/nixpkgs/commit/58546a5f78f5a4dd90d08b4a3a09a70bec15158a) | `thedesk: switch to electron-14`                                                    |
| [`53ded9e4`](https://github.com/NixOS/nixpkgs/commit/53ded9e4caff98ec61f95ed88ccf1d6ff4c3ed6d) | `etcher: switch to electron_14`                                                     |
| [`3c35508d`](https://github.com/NixOS/nixpkgs/commit/3c35508df52b49b234d4e31c58d5573bba27cfb7) | `geogebra6: switch to electron_14`                                                  |
| [`777f55b7`](https://github.com/NixOS/nixpkgs/commit/777f55b7366476acccd3bb8164793d39015669b0) | `beamerpresenter: 0.2.0 -> 0.2.1`                                                   |
| [`3bc5c9a8`](https://github.com/NixOS/nixpkgs/commit/3bc5c9a8ace4582894399eaa19d90204998b0b7b) | `jetbrains: 2021.2.3 -> 2021.3`                                                     |
| [`195f1353`](https://github.com/NixOS/nixpkgs/commit/195f13535760590432fabc737a428b96edaea883) | `twinkle: 1.10.2 -> unstable-2021-02-06`                                            |
| [`5baed799`](https://github.com/NixOS/nixpkgs/commit/5baed79906b556d80290b4df07ab53e56e5f01bc) | `sof-firmware: 1.9 -> 1.9.2`                                                        |
| [`68201583`](https://github.com/NixOS/nixpkgs/commit/68201583056b6183d284754d0315be97e4c25b50) | `sgx-sdk: fix typo`                                                                 |
| [`406fb9b1`](https://github.com/NixOS/nixpkgs/commit/406fb9b14db226fed9b49d6e95b0373683b2a586) | `sgx-sdk: use sgx_ippcp.h from prebuilt optimized libraries`                        |
| [`4d468992`](https://github.com/NixOS/nixpkgs/commit/4d4689928936ba6cf0a80135a95e100eaf8f5b8c) | `sgx-sdk: use SRI hash`                                                             |
| [`8741f92e`](https://github.com/NixOS/nixpkgs/commit/8741f92e1ad7b29f06eeec0628a4c1f49dd49872) | `genpass: 0.4.12 -> 0.5.1`                                                          |
| [`3a58cd41`](https://github.com/NixOS/nixpkgs/commit/3a58cd414fcca910a9fba428e74fa64c2438071f) | `lndmanage: 0.13.0 -> 0.14.0`                                                       |
| [`d6a0da1e`](https://github.com/NixOS/nixpkgs/commit/d6a0da1e5dff14feb3b783eb1590f92f9725847a) | `sgx-sdk: use full version`                                                         |
| [`a25482ff`](https://github.com/NixOS/nixpkgs/commit/a25482ffa725d306558d0a88db9aaac29cc54759) | `sgxsdk: use samples as passthru tests`                                             |
| [`007b6068`](https://github.com/NixOS/nixpkgs/commit/007b606892f7b738495e8dd1b413a451edc09be9) | `sgxsdk: add setup hook`                                                            |
| [`91cd6660`](https://github.com/NixOS/nixpkgs/commit/91cd6660108d3ee1d2c98b70726b2531166d39de) | `sgx-sdk: nits`                                                                     |
| [`e74ffcd3`](https://github.com/NixOS/nixpkgs/commit/e74ffcd3665dd61965f6040e6ced86b6f9804389) | `sgx-sdk: rework `installCheckPhase``                                               |
| [`cd057031`](https://github.com/NixOS/nixpkgs/commit/cd057031317107f327c5080bc41923c510a38c15) | `sgx-sdk: fix BINUTILS_DIR substitute`                                              |
| [`8c2b6bba`](https://github.com/NixOS/nixpkgs/commit/8c2b6bbaefb2b2ea54d22715e813e1bed0579cbb) | `sgx-sdk: add veehaitch as a maintainer`                                            |
| [`867f6ffc`](https://github.com/NixOS/nixpkgs/commit/867f6ffcd3a3e3c3638cc2fa498fd661289b2aa2) | `sgx-sdk: build and run most samples in `installCheckPhase``                        |
| [`4bad549b`](https://github.com/NixOS/nixpkgs/commit/4bad549b76da69fffd54ab6d9369ed26113dc1ca) | `sgx-sdk: create Nix output directory structure`                                    |
| [`92df329a`](https://github.com/NixOS/nixpkgs/commit/92df329a98767ead857b9c418f1991c2c58294b1) | `sgx-sdk: use `header` command`                                                     |
| [`a3b69162`](https://github.com/NixOS/nixpkgs/commit/a3b69162e9eab04801d428a0b306b9f98f00d01e) | `sgx-sdk: fix sgx-gdb`                                                              |
| [`141e8153`](https://github.com/NixOS/nixpkgs/commit/141e8153fbf325bade994682e3aa210a701371de) | `sgx-sdk: fix pkg-config files`                                                     |
| [`89929bac`](https://github.com/NixOS/nixpkgs/commit/89929bacab3909b981ecd3ca1e23cd400e93d0ca) | `sgx-sdk: remove superfluous `nasm` input`                                          |
| [`0a23f360`](https://github.com/NixOS/nixpkgs/commit/0a23f360eeb49f65c6264a45d88a03982b8d1c30) | `sgx-sdk: use install(5)`                                                           |
| [`e08d39da`](https://github.com/NixOS/nixpkgs/commit/e08d39daa6a126478647072a62c6809596692434) | `sgx-sdk: use buildPhase attrs, run hooks, sort`                                    |
| [`96936f62`](https://github.com/NixOS/nixpkgs/commit/96936f625468047b46a3ffdd35e823a7de8caa33) | `sgx-sdk: use tag instead of commit hash`                                           |
| [`32375fb9`](https://github.com/NixOS/nixpkgs/commit/32375fb97cef0c23ab41141ca475d1bd2da79481) | `sgx-sdk: eliminate `patches``                                                      |
| [`2fcfe8c8`](https://github.com/NixOS/nixpkgs/commit/2fcfe8c830428928a16bd5c4d9dfb426ba5b534c) | `sgx-sdk: `nixpkgs-fmt``                                                            |
| [`a3358146`](https://github.com/NixOS/nixpkgs/commit/a3358146dff95aacfaf727555843a08cbfe91cdc) | `nixos/mx-puppet-discord: provide registration file & fix typo in settings example` |