### PR TITLE
chore(flake/poetry2nix): `41732777` -> `a4b76920`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638221212,
-        "narHash": "sha256-q0538K4nzLlhQoDV1lvNZgONlkW/KmFAoMfVET2G8uU=",
+        "lastModified": 1638854297,
+        "narHash": "sha256-mt5gMwAThp8FpcvRsKhs/y/VxLDNgH4MJJLlFbbs4gk=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "417327774668d33c7792c1f8b20407a550b66517",
+        "rev": "a4b769203284c91529480adcbb4f17f04d3ff67b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                    | Commit Message                                    |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`58ef019d`](https://github.com/nix-community/poetry2nix/commit/58ef019d39aa12b05bba68936b57331a1892dc66) | `overrides: scipy: fix for version >= 1.7.0`      |
| [`3def814c`](https://github.com/nix-community/poetry2nix/commit/3def814c0a31a4edb9dc1333838e02b2efa6fac3) | `overrides: wtforms: add`                         |
| [`64da99c7`](https://github.com/nix-community/poetry2nix/commit/64da99c770026a517521d690ea21010450b1d781) | `overrides: matplotlib: fix for version >= 3.5.0` |
| [`1c5ee0df`](https://github.com/nix-community/poetry2nix/commit/1c5ee0df4350c4834ee07461576a11043617da2c) | `add absl-py as tensorboard dependency`           |