### PR TITLE
chore(flake/nixpkgs): `63628eb0` -> `f2365edc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638785989,
-        "narHash": "sha256-AuBr5/j2oOHJjN3sA0B6RaeRONzMv1g/CHgkTm0jx2M=",
+        "lastModified": 1638830384,
+        "narHash": "sha256-vWyUvatWvfBazir6cHrDJsdZEPmxUr7aDU/mBD6oR3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63628eb0a47129f3c10865da5811652619effc8a",
+        "rev": "f2365edc3095a479206cfc6825b23b032d79e785",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`74d8cc01`](https://github.com/NixOS/nixpkgs/commit/74d8cc01903dc3391fafa13be4148985b93c3491) | `evolution-data-server: 3.42.1 -> 3.42.2`                                 |
| [`0a0a8ebc`](https://github.com/NixOS/nixpkgs/commit/0a0a8ebc51906c8c341d50fe5a2a4367e7a83c06) | `python38Packages.soco: 0.24.1 -> 0.25.0`                                 |
| [`7483fa78`](https://github.com/NixOS/nixpkgs/commit/7483fa7825883ffab740d26ee21247e804928ad6) | `sn0int: 0.23.0 -> 0.24.1`                                                |
| [`93d2a95a`](https://github.com/NixOS/nixpkgs/commit/93d2a95a86b6ac6daedf76779e00652c13abf114) | `python38Packages.channels-redis: 3.2.0 -> 3.3.1`                         |
| [`08a105d0`](https://github.com/NixOS/nixpkgs/commit/08a105d0cdd8e62296887da92c52ef02bd53fd6b) | `python38Packages.cloudsmith-api: 0.54.15 -> 0.57.1`                      |
| [`7867e316`](https://github.com/NixOS/nixpkgs/commit/7867e3165a1affa19d4aecfcdd0324b3bae0da84) | `python38Packages.screenlogicpy: 0.5.0 -> 0.5.3`                          |
| [`1dfc1477`](https://github.com/NixOS/nixpkgs/commit/1dfc147773017fb001a44ba4f939e19e9830e90a) | `delta: 0.11.0 -> 0.11.1`                                                 |
| [`c6a321d1`](https://github.com/NixOS/nixpkgs/commit/c6a321d18c1a31c7b12c723ca6118f9ac4de3737) | `conmon: 2.0.30 -> 2.0.31`                                                |
| [`54eac080`](https://github.com/NixOS/nixpkgs/commit/54eac080d1d9ed935c4908c4d9ef7f571beacb03) | `python38Packages.screeninfo: 0.7 -> 0.8`                                 |
| [`cdaa4ce2`](https://github.com/NixOS/nixpkgs/commit/cdaa4ce25b74ed006b110e2a635eade0e3f18980) | `sabnzbd: 3.4.1 -> 3.4.2`                                                 |
| [`daea8e9a`](https://github.com/NixOS/nixpkgs/commit/daea8e9a82b2311b94a8a9056c6f6f7d7b6f9cee) | `sabnzbd: 3.4.0 -> 3.4.1`                                                 |
| [`9f45c185`](https://github.com/NixOS/nixpkgs/commit/9f45c185155f92f8c6adddcb5fa64b7849d8f382) | `sabnzbd: add simple test`                                                |
| [`12efd19b`](https://github.com/NixOS/nixpkgs/commit/12efd19b16bfcc6f1bf2163cff3797fa03297390) | `sabnzbd: add jojosch as maintainer`                                      |
| [`68bce5b3`](https://github.com/NixOS/nixpkgs/commit/68bce5b37706aee12677ada7a30f0afbe48fc7f9) | `sabnzbd: add missing dependencies`                                       |
| [`fb881b80`](https://github.com/NixOS/nixpkgs/commit/fb881b80f64d1b672135533a8c2fbc86e6ed8898) | `ocamlPackages.js_build_tools: remove at 113.33.06`                       |
| [`42630901`](https://github.com/NixOS/nixpkgs/commit/4263090128b8ce78fdb04d6c1814d3b50e3036c5) | `ocamlPackages.buildOcamlJane: remove`                                    |
| [`9f39cd80`](https://github.com/NixOS/nixpkgs/commit/9f39cd801b40162a12113dbfdf3c297e5f30406c) | `pkgs/development/ocaml-modules/janestreet/: remove dead code`            |
| [`c408cfdf`](https://github.com/NixOS/nixpkgs/commit/c408cfdf50a7f152d1e695dedba0321e8ed4268e) | `ocamlPackages.variantslib: remove at 109.15.03 & 113.33.03`              |
| [`74032d76`](https://github.com/NixOS/nixpkgs/commit/74032d767ad100899bdc9e758b236aafc8c0a8ff) | `ocamlPackages.typerep: remove at 112.24.00 & 113.33.03`                  |
| [`efd2b3f3`](https://github.com/NixOS/nixpkgs/commit/efd2b3f315561872718d8dae57cbf03a484c356c) | `ocamlPackages.fieldslib: remove at 109.20.03 & 113.33.03`                |
| [`ec71290d`](https://github.com/NixOS/nixpkgs/commit/ec71290dc27e71ce73bd4780299961dcae6e9758) | `ocamlPackages.bin_prot: remove at 112.24.00 & 113.33.03`                 |
| [`e97eeaca`](https://github.com/NixOS/nixpkgs/commit/e97eeacafc6da02f9f6624e7c0142b8599ce9aed) | `f3d: 1.1.1 -> 1.2.0`                                                     |
| [`3f0803c9`](https://github.com/NixOS/nixpkgs/commit/3f0803c9baacfd020017cbc8ab6d289296ded120) | `python38Packages.bitlist: 0.6.1 -> 0.6.2`                                |
| [`08aa310f`](https://github.com/NixOS/nixpkgs/commit/08aa310feb5ec9dbb154b48037eba1d0d7961216) | `maintainers: add hyshka`                                                 |
| [`f08bd4e1`](https://github.com/NixOS/nixpkgs/commit/f08bd4e1aca707979c7859ecb43ed7c76ef75483) | `stagit: 0.9.6 -> 1.0`                                                    |
| [`96d69e40`](https://github.com/NixOS/nixpkgs/commit/96d69e40f24409758a8effc70027285b79d8846b) | `nixos/zigbee2mqtt: run as zigbee2mqtt group`                             |
| [`f277b094`](https://github.com/NixOS/nixpkgs/commit/f277b0945ea9c7759d222148e360532d253d2d46) | `zigbee2mqtt: remove upgrade warning`                                     |
| [`200c3625`](https://github.com/NixOS/nixpkgs/commit/200c36255fd7acbb135e64009adb481c0467520e) | `nixos/zigbee2mqtt: no longer pass dataDir to package`                    |
| [`1e3e9410`](https://github.com/NixOS/nixpkgs/commit/1e3e941051663d4f8bf7edc94a6bff0ae8ad9a8c) | `python38Packages.aionanoleaf: 0.0.4 -> 0.1.1`                            |
| [`5187d842`](https://github.com/NixOS/nixpkgs/commit/5187d8420f4c9bee68d3369296b83b6c15cff1a0) | `swayr: 0.10.0 -> 0.10.1`                                                 |
| [`3d39d8b3`](https://github.com/NixOS/nixpkgs/commit/3d39d8b32aea6503dec1183a85639aae9e4bf62e) | `exploitdb: 2021-12-02 -> 2021-12-04`                                     |
| [`5958a699`](https://github.com/NixOS/nixpkgs/commit/5958a6990d4dbdd4bcc2e2153f5f6da3f39b8298) | `eksctl: 0.71.0 -> 0.76.0`                                                |
| [`13395953`](https://github.com/NixOS/nixpkgs/commit/13395953bd0106dba778fdf9dfd87709fadb90c4) | `efm-langserver: 0.0.37 -> 0.0.38`                                        |
| [`797f59b6`](https://github.com/NixOS/nixpkgs/commit/797f59b6a6bdbbb8d1927c1cf4824f461de9d9af) | `dyff: 1.4.5 -> 1.4.6`                                                    |
| [`e9b94beb`](https://github.com/NixOS/nixpkgs/commit/e9b94beba4a43e985b8898b8346b700057ba6400) | `duckdb: 0.3.0 -> 0.3.1`                                                  |
| [`bc5d6830`](https://github.com/NixOS/nixpkgs/commit/bc5d68306b40b8522ffb69ba6cff91898c2fbbff) | `elixir_1_13: init (#148619)`                                             |
| [`ad4b1eb1`](https://github.com/NixOS/nixpkgs/commit/ad4b1eb16118e789c644f3d38d2ed9c7cd4b0e9f) | `arduino: use buildFHSUserEnv to support compilation of boards (#144772)` |
| [`e6d91c74`](https://github.com/NixOS/nixpkgs/commit/e6d91c74b07339202a0acdaa3bd407c22ff89b68) | `vector: 0.18.0 -> 0.18.1 (#149019)`                                      |
| [`113f047a`](https://github.com/NixOS/nixpkgs/commit/113f047ae77c12f98cb3ba56bed25aad96425d4c) | `open-watcom-v2: init at unstable 2021-11-30 (#124000)`                   |
| [`8e6d5313`](https://github.com/NixOS/nixpkgs/commit/8e6d5313946c68e091248c472ca8a9a654ad45ad) | `socat: 1.7.4.1 -> 1.7.4.2`                                               |
| [`65b2df8b`](https://github.com/NixOS/nixpkgs/commit/65b2df8b45b04362670950d9ba838abfaf712e79) | `golly: 3.3 -> 4.1`                                                       |
| [`f8c33483`](https://github.com/NixOS/nixpkgs/commit/f8c33483aaaa5653d78fddf354cb511b17ed0325) | `sonobuoy: 0.55.0 -> 0.55.1`                                              |
| [`ca1f2a9e`](https://github.com/NixOS/nixpkgs/commit/ca1f2a9ed26e91cfaa7654b4685090cc34ab73c3) | `oh-my-zsh: 2021-11-11 -> 2021-12-02`                                     |
| [`3975da9a`](https://github.com/NixOS/nixpkgs/commit/3975da9a0e4a01b99fd76e636487595f7a486460) | `php74Extensions.blackfire: 1.69.0 -> 1.70.0`                             |
| [`6c4a8c77`](https://github.com/NixOS/nixpkgs/commit/6c4a8c770f68ae1316f09e003c27ed9c308cdf03) | `texstudio: 4.0.2 -> 4.1.1`                                               |
| [`73abda99`](https://github.com/NixOS/nixpkgs/commit/73abda994e34a1063961e97a2138e842e16dda55) | `docker-buildx: 0.6.3 -> 0.7.1`                                           |
| [`b9f5b8dc`](https://github.com/NixOS/nixpkgs/commit/b9f5b8dce796c765fee7974569f272c2ade0f688) | `pangomm_2_48: 2.48.1 -> 2.48.2`                                          |
| [`1ffd6d6f`](https://github.com/NixOS/nixpkgs/commit/1ffd6d6f1fc137bef0313e382d9c44635c5a6a11) | `python38Packages.cysignals: 1.10.3 -> 1.11.1`                            |
| [`5e69c0d2`](https://github.com/NixOS/nixpkgs/commit/5e69c0d2f45bdd526436d5dc75daff0abf2ad092) | `delve: 1.7.2 -> 1.7.3`                                                   |
| [`4065ea45`](https://github.com/NixOS/nixpkgs/commit/4065ea45e603f8d79c1ae878970f40b20a27303d) | `ddcutil: 1.2.0 -> 1.2.1`                                                 |
| [`5da3f0d3`](https://github.com/NixOS/nixpkgs/commit/5da3f0d3bda5208db70f02e1260de6c0ac1bfe79) | `ustreamer: 4.6 -> 4.9`                                                   |
| [`65b3286a`](https://github.com/NixOS/nixpkgs/commit/65b3286a92daf3ab123e23d6af6856d421672b83) | `unrar: 6.0.7 -> 6.1.2`                                                   |
| [`8ddfe2fb`](https://github.com/NixOS/nixpkgs/commit/8ddfe2fb53740b31797a2bd7cc8354282c7dd424) | `vgrep: 2.5.3 -> 2.5.5`                                                   |
| [`54fcdaa6`](https://github.com/NixOS/nixpkgs/commit/54fcdaa6b983f86389bd057e99e6cca920985a46) | `ocamlPackages.optcomp: remove broken`                                    |
| [`fed5706e`](https://github.com/NixOS/nixpkgs/commit/fed5706e4ae825bd74111406ede7352d1a73df73) | `ocamlPackages.ocsigen_deriving: 0.8.1 → 0.8.2`                           |
| [`95c9e457`](https://github.com/NixOS/nixpkgs/commit/95c9e45744c95f38236b6404e5103c960ed2ca76) | `dalfox: 2.5.4 -> 2.6.1`                                                  |
| [`1fe40452`](https://github.com/NixOS/nixpkgs/commit/1fe40452cd0246c1bd6686b6e6402e520cd2bba1) | `python38Packages.pyfronius: 0.7.0 -> 0.7.1`                              |
| [`7aaac1e9`](https://github.com/NixOS/nixpkgs/commit/7aaac1e92fee5af9ab0db82d2b304e8cc002a4ff) | `crowdin-cli: 3.7.1 -> 3.7.2`                                             |
| [`8842ca4b`](https://github.com/NixOS/nixpkgs/commit/8842ca4b9f71ac2870d4207023e5966d55af3b47) | `ugrep: 3.3.8 -> 3.3.10`                                                  |
| [`4baf742d`](https://github.com/NixOS/nixpkgs/commit/4baf742d97f757a8270fe0021ec8e5bf10bdd815) | `containerd: 1.5.7 -> 1.5.8`                                              |
| [`ed83b871`](https://github.com/NixOS/nixpkgs/commit/ed83b8714b5dc83d1688688c629c0f328ad5fad9) | `python38Packages.parts: 1.2.0 -> 1.2.2`                                  |
| [`0aa2bd0a`](https://github.com/NixOS/nixpkgs/commit/0aa2bd0aff09698aae8214855104a9e9e335e098) | `tutanota-desktop: 3.89.5 -> 3.89.23`                                     |
| [`c54390f3`](https://github.com/NixOS/nixpkgs/commit/c54390f3187e664cff7ce6f786ce0baf33c9c962) | `codeql: 2.7.0 -> 2.7.2`                                                  |
| [`3ed02863`](https://github.com/NixOS/nixpkgs/commit/3ed02863b672f9a939f8debe055694b8397196d8) | `mkgmap-splitter: 643 -> 645`                                             |
| [`d87c46d7`](https://github.com/NixOS/nixpkgs/commit/d87c46d72d209cbab47cbe51e5502cabcd6a2b2f) | `mkgmap: 4813 -> 4827`                                                    |
| [`be65588e`](https://github.com/NixOS/nixpkgs/commit/be65588e5d5ee37fa72cecffc347bbc5895f9a52) | `haskell.packages.ghc921.memory: ensure head.hackage patch applies`       |
| [`aebed225`](https://github.com/NixOS/nixpkgs/commit/aebed22519b369bfe90dfaa2e18c6efc341d8ff2) | `python38Packages.azure-mgmt-containerservice: 16.3.0 -> 16.4.0`          |
| [`d5368e3b`](https://github.com/NixOS/nixpkgs/commit/d5368e3bdb027bd5e5989415a989582a4148cb65) | `clingo: 5.5.0 -> 5.5.1`                                                  |
| [`c9731524`](https://github.com/NixOS/nixpkgs/commit/c9731524263fdda0e16586f24e00a4066f458170) | `typos: 1.3.0 -> 1.3.1`                                                   |
| [`056be23a`](https://github.com/NixOS/nixpkgs/commit/056be23aa98d6a888b32688720a9c34798fd56ca) | `tigervnc: 1.11.0 -> 1.12.0`                                              |
| [`e4f017ce`](https://github.com/NixOS/nixpkgs/commit/e4f017ce56d2a9241d0e147b376558e138e11cec) | `avro-cpp: use python3, move to nativeBuildInputs`                        |
| [`9e8df69a`](https://github.com/NixOS/nixpkgs/commit/9e8df69a9f0ab8c4b97d7e0132e45cd650cd8993) | `escrotum: 2019-06-10 -> 2020-12-07`                                      |
| [`d88a1cf6`](https://github.com/NixOS/nixpkgs/commit/d88a1cf68333c7bac12426ab11b2735fa3fba1db) | `cargo-expand: 1.0.9 -> 1.0.10`                                           |
| [`445289b1`](https://github.com/NixOS/nixpkgs/commit/445289b1db6adfeed4a1d49b080b76d35ba15702) | `gnome-connections: 41.1 -> 41.2`                                         |
| [`73adab15`](https://github.com/NixOS/nixpkgs/commit/73adab1541ecf0289930fee78d7760973940d106) | `terraform-ls: 0.23.0 -> 0.25.0`                                          |
| [`71b451a6`](https://github.com/NixOS/nixpkgs/commit/71b451a6d14a02fae1804009cda8e17505c3bb65) | `gnome.gnome-software: 41.1 -> 41.2`                                      |
| [`29634b20`](https://github.com/NixOS/nixpkgs/commit/29634b2031e788ae404e4b7558856b4fa4a0308b) | `gnome.gnome-maps: 41.1 -> 41.2`                                          |
| [`e73b68e4`](https://github.com/NixOS/nixpkgs/commit/e73b68e497c768aec42eab10fe8f5407dc029b7f) | `gnome.gnome-initial-setup: 41.0 -> 41.2`                                 |
| [`6f92de7d`](https://github.com/NixOS/nixpkgs/commit/6f92de7d792876417cc2ab2a70c5992f15dee163) | `binance: 1.26.0 -> 1.27.0`                                               |
| [`7b698e4d`](https://github.com/NixOS/nixpkgs/commit/7b698e4d81fc4f2e890560819e98f768604285af) | `gnome.gnome-control-center: 41.1 -> 41.2`                                |
| [`26c5db5a`](https://github.com/NixOS/nixpkgs/commit/26c5db5aad8c9f42538b531f79b829107016bed3) | `gnome.gnome-boxes: 41.1 -> 41.2`                                         |
| [`0c02c533`](https://github.com/NixOS/nixpkgs/commit/0c02c53354fc393cd443fe8433373f5ed8639a93) | `gnome.ghex: 3.41.0 -> 3.41.1`                                            |
| [`ec7e2ca0`](https://github.com/NixOS/nixpkgs/commit/ec7e2ca004fcfe5f829b542cd8629dd1f1ae8008) | `gnome.yelp: 41.1 -> 41.2`                                                |
| [`717f761e`](https://github.com/NixOS/nixpkgs/commit/717f761eee8f0bca4489f9c1a86b0049c83889a6) | `gnome.eog: 41.0 -> 41.1`                                                 |
| [`ba5adfe1`](https://github.com/NixOS/nixpkgs/commit/ba5adfe1f175cc21ce502e1f7faf9de12af469cb) | `gnome.aisleriot: 3.22.19 -> 3.22.20`                                     |
| [`4da06aae`](https://github.com/NixOS/nixpkgs/commit/4da06aaede874acb812853ee7a1e3691e356614c) | `gitRepo: 2.17.3 -> 2.18`                                                 |
| [`95a7d1ed`](https://github.com/NixOS/nixpkgs/commit/95a7d1ed78508b0f485d8ce1377e41cb1372605a) | `gnome.yelp-xsl: 41.0 -> 41.1`                                            |
| [`1c4fa520`](https://github.com/NixOS/nixpkgs/commit/1c4fa520d6e7e8e97a98e3c78ae8e4a3a38fa090) | `deno: 1.16.3 -> 1.16.4`                                                  |
| [`ef708d2c`](https://github.com/NixOS/nixpkgs/commit/ef708d2c4dfb7ccc0f0ae84eceae2e59400f34c5) | `khronos: 3.6.1 -> 3.6.6`                                                 |
| [`9981e3d0`](https://github.com/NixOS/nixpkgs/commit/9981e3d0304e87fb58f773a7bd47e8436f4e7768) | `astc-encoder: 3.2 -> 3.3`                                                |
| [`521f30f8`](https://github.com/NixOS/nixpkgs/commit/521f30f80cf7d8d7489f9b8799999d27b390675e) | `claws-mail: remove claws-mail-gtk2 version`                              |
| [`89158eae`](https://github.com/NixOS/nixpkgs/commit/89158eae07563ec21163929f49d9e2d3e918f118) | `blahtexml: init at 0.9+date=2020-05-16`                                  |
| [`759ab2ea`](https://github.com/NixOS/nixpkgs/commit/759ab2eaa38e7fc920b68d2515085e500b01e13a) | `cinnamon.xreader: 3.0.2 -> 3.2.1`                                        |
| [`56aadd1e`](https://github.com/NixOS/nixpkgs/commit/56aadd1e53d199d9511420810c0b8ebd3089c600) | `alertmanager-irc-relay: 0.4.2 -> 0.4.3`                                  |
| [`ce599511`](https://github.com/NixOS/nixpkgs/commit/ce599511844e049e91e198436cf5b1dd1183ad30) | `python38Packages.datamodeldict: 0.9.7 -> 0.9.8`                          |
| [`be9ab66f`](https://github.com/NixOS/nixpkgs/commit/be9ab66f38a67fc60e1acbf87c4bf177eb60025b) | `python38Packages.sunpy: 3.1.1 -> 3.1.2`                                  |
| [`0ba33772`](https://github.com/NixOS/nixpkgs/commit/0ba337725eacaa78798c95042b82d9de2d51cda6) | `zigbee2mqtt: remove local node-env, since it's not used any longer`      |
| [`b7907f7e`](https://github.com/NixOS/nixpkgs/commit/b7907f7e19b1c3320c6bf5e41407fe2dab3d30d8) | `zigbee2mqtt: 1.16.2 -> 1.22.1`                                           |
| [`6d1ca973`](https://github.com/NixOS/nixpkgs/commit/6d1ca973c733c09d9e317136a0e24ebe7172e6bb) | `zigbee2mqtt: transpile typescript in post install hook`                  |
| [`95d8e017`](https://github.com/NixOS/nixpkgs/commit/95d8e017775871b82a83c4954b81094f840034f6) | `haskellPackages.proto-lens: drop now unnecessary override`               |
| [`53cd2570`](https://github.com/NixOS/nixpkgs/commit/53cd25707b95e1dc0d0840c4736c2895f6ee2fc1) | `haskellPackages.jet: allow building with recursive-zipper 0.0.0.1`       |
| [`0b87a7d8`](https://github.com/NixOS/nixpkgs/commit/0b87a7d8902800714ec6f899db2a52616add716c) | `haskellPackages: mark builds failing on hydra as broken`                 |
| [`b20f762d`](https://github.com/NixOS/nixpkgs/commit/b20f762dfd32a58cd66405f357b70195862761c7) | `python3Packages.myhome: init at 0.2.1`                                   |
| [`87c14165`](https://github.com/NixOS/nixpkgs/commit/87c14165debe5404affde9cc78280383bbc23bf8) | `haskellPackages.photoname: disable test suite requiring stack`           |
| [`f963842b`](https://github.com/NixOS/nixpkgs/commit/f963842b02886d87fea3ac394add6ae504f49a0b) | `haskell.packages.ghc901.text-short: 0.1.3 -> 0.1.4`                      |
| [`5fcda750`](https://github.com/NixOS/nixpkgs/commit/5fcda75017fc78fdb562c941ffb51710e7fb0afd) | `haskell.packages.ghc901.{multistate,butcher}: jailbreak`                 |
| [`b56049c4`](https://github.com/NixOS/nixpkgs/commit/b56049c449db89b94c7c79f07646cfb9f3106936) | `haskellPackages.brittany: pin to 0.13.1.2`                               |
| [`eb1bdd9f`](https://github.com/NixOS/nixpkgs/commit/eb1bdd9f8c063d74234babbbdf02b7c6b827a9af) | `haskellPackages.dhall-nixpkgs: generate shell completions`               |
| [`5606343a`](https://github.com/NixOS/nixpkgs/commit/5606343aa538da916fa6c6f03837544b218ee624) | `haskellPackages.dhall-nixpkgs: use revised cabal file`                   |
| [`a5627be4`](https://github.com/NixOS/nixpkgs/commit/a5627be4f18b6397338d91e93cccf9fd258956fd) | `python3Packages.pkginfo: 1.8.1 -> 1.8.2`                                 |
| [`8ea82df7`](https://github.com/NixOS/nixpkgs/commit/8ea82df76d9c0e11ddc830ed39d4075e6c5eb84f) | `python3Packages.pygogo: update checkPhase`                               |
| [`a5736f1f`](https://github.com/NixOS/nixpkgs/commit/a5736f1f8a128ed046b0e45d31376550b06c0529) | `python3Packages.pkutils: 1.1.1. -> 2.0.0`                                |
| [`fc4df13e`](https://github.com/NixOS/nixpkgs/commit/fc4df13e2667134772c1551e3feb47be0b5b6b23) | `nixos: add sgx group with gid 304`                                       |
| [`42fdb058`](https://github.com/NixOS/nixpkgs/commit/42fdb058dd4f6a7ad6a23dbccb8bd6a510cad0da) | `python3Packages.mediafile: enable tests`                                 |
| [`4e04f239`](https://github.com/NixOS/nixpkgs/commit/4e04f239a16383d5e9d30c0f11c2b274d255a6ad) | `python3Packages.mediafile: 0.8.1 -> 0.9.0`                               |
| [`46631f08`](https://github.com/NixOS/nixpkgs/commit/46631f08a80d322e239dd8bd4af786d9d0e04e0a) | `haskellPackages.rel8: downgrade to 1.2.0.0 for stackage LTS compat`      |
| [`85b9ba0c`](https://github.com/NixOS/nixpkgs/commit/85b9ba0ccd94435ead007c23ec218e8e3e4aef6c) | `haskellPackages.git-annex: update sha256 for 8.20211123`                 |
| [`d6d8eddc`](https://github.com/NixOS/nixpkgs/commit/d6d8eddce45068b1a1c911273871340d7ccfce23) | `haskell.packages.ghc921.ormolu: 0.1.4.1 -> 0.4.0.0`                      |
| [`a4f68278`](https://github.com/NixOS/nixpkgs/commit/a4f68278eb159d3b963c044884706efbe5d95ac8) | `haskell.packages.ghc901.weeder: jailbreak to allow lens 5.1`             |
| [`d5ab0018`](https://github.com/NixOS/nixpkgs/commit/d5ab00182b2048fc1eb128281725ed7a40ab977f) | `haskell.packages.ghc921.quickcheck-instances: 0.3.26.1 -> 0.3.27`        |
| [`0fee3e13`](https://github.com/NixOS/nixpkgs/commit/0fee3e1309acc0c94be8624c1d097e06cd9d5571) | `haskell.packages.ghc901: adjust to dhall hackage update`                 |
| [`12e94a51`](https://github.com/NixOS/nixpkgs/commit/12e94a519bc861c1bb21dfc3dbd95121171c6c19) | `haskell.packages.ghc901.ormolu: pin to 0.3.*`                            |
| [`417a1da7`](https://github.com/NixOS/nixpkgs/commit/417a1da7e078ce2024aae6a35f41dd442dac7138) | `haskell.packages.ghc901.path: pin to 0.9.0`                              |
| [`c5757418`](https://github.com/NixOS/nixpkgs/commit/c5757418a9e3e1db0ba8ed07be8e4934bf7ea103) | `hledger-check-fancyassertions: use hledger-lib 1.24`                     |
| [`dccf15a3`](https://github.com/NixOS/nixpkgs/commit/dccf15a33cfb2511044e0f9480c2287c8370f475) | `haskellPackages.graphql-engine: adjust to hspec hackage update`          |
| [`44012780`](https://github.com/NixOS/nixpkgs/commit/44012780f72f013ff49f980df4047b8e916ecc68) | `haskellPackages.hledger_1_24: init at 1.24`                              |
| [`016839f1`](https://github.com/NixOS/nixpkgs/commit/016839f1db551a507084370a067e32a48fef9b73) | `haskellPackages.hadolint: reflect dependency hackage updates`            |
| [`ecc88d7a`](https://github.com/NixOS/nixpkgs/commit/ecc88d7a5c0317034ac7090f504e022717162460) | `haskellPackages.ghcup: reflect streamly hackage update`                  |
| [`91dcbd45`](https://github.com/NixOS/nixpkgs/commit/91dcbd453f2e5ee7ce0e20e3d86e299ac1ca5da9) | `python3Packages.build: 0.5.1 -> 0.7.0`                                   |
| [`6852fdd5`](https://github.com/NixOS/nixpkgs/commit/6852fdd5ad689db63c7648779b0e6fd6f4cf09cf) | `haskell.packages.ghc921.hashable: reflect hackage update`                |
| [`85413090`](https://github.com/NixOS/nixpkgs/commit/85413090da8b665f5a7d62304041ed4bd0668d1d) | `haskellPackages.brick_0_64_2: preserve for matterhorn`                   |
| [`5a49142a`](https://github.com/NixOS/nixpkgs/commit/5a49142a4f94f2d70ebadc6c96efedf8f63e01c0) | `nix-tree: build with latest brick`                                       |
| [`c57f5d5d`](https://github.com/NixOS/nixpkgs/commit/c57f5d5d05264a3ad1f992f3ce4430976539f7dc) | `haskellPackages.paramtree: update comment for dontCheck override`        |
| [`6727f1e4`](https://github.com/NixOS/nixpkgs/commit/6727f1e420c523d033a05e1ba9cac73884f60bad) | `haskell.packages.ghc901.extras: drop now unnecessary override`           |
| [`757dd008`](https://github.com/NixOS/nixpkgs/commit/757dd008b2f2926fc0f7688fa8189f930ea47521) | `postgresql_9_6: drop`                                                    |
| [`9ee79763`](https://github.com/NixOS/nixpkgs/commit/9ee79763f093da572da7271e0f692929c55d20df) | `haskellPackages: regenerate package set based on current config`         |
| [`3619ce10`](https://github.com/NixOS/nixpkgs/commit/3619ce10710dbee4cedc032b1c3ad5457707f890) | `all-cabal-hashes: 2021-11-18T20:32:52Z -> 2021-12-02T21:05:02Z`          |
| [`038201eb`](https://github.com/NixOS/nixpkgs/commit/038201ebdb2adeaaae81723a6e3a60f1e2fe9db1) | `haskellPackages: stackage-lts 18.17 -> 18.18`                            |
| [`3507c877`](https://github.com/NixOS/nixpkgs/commit/3507c8777462d1d7656c8ebb69636b96136abab4) | `zigbee2mqtt: improve update script`                                      |
| [`e267ff0f`](https://github.com/NixOS/nixpkgs/commit/e267ff0f39dc7cb7c840316891e0f8a19526c504) | `zigbee2mqtt: drop leftover dataDir parameter`                            |
| [`abfcb79a`](https://github.com/NixOS/nixpkgs/commit/abfcb79abf3ba32eb4719c48915a143370093fb7) | `nixos: make GIO_EXTRA_MODULES a session variable`                        |