### PR TITLE
fix: handle underscores in package names

### DIFF
--- a/protoletariat/rewrite.py
+++ b/protoletariat/rewrite.py
@@ -180,7 +180,10 @@ def build_rewrites(proto: str, dep: str) -> list[Replacement]:
         new = f"from {leading_dots} import {part}_pb2 as {last_part}"
     else:
         from_ = ".".join(import_parts)
-        as_ = f"{'_dot_'.join(import_parts)}_dot_{last_part}"
+        fake_dotted_path = "_dot_".join(
+            part.replace("_", "__") for part in import_parts
+        )
+        as_ = f"{fake_dotted_path}_dot_{last_part}"
 
         old = f"from {from_} import {part}_pb2 as {as_}"
         new = f"from {leading_dots}{from_} import {part}_pb2 as {as_}"

--- a/protoletariat/tests/test_rewrite.py
+++ b/protoletariat/tests/test_rewrite.py
@@ -93,6 +93,15 @@ from protoletariat.rewrite import build_rewrites
             ],
             id="self_dep",
         ),
+        pytest.param(
+            "a_b/c",
+            "foo_bar/baz/bizz",
+            [
+                "from ..foo_bar.baz import bizz_pb2 as foo__bar_dot_baz_dot_bizz__pb2",
+                "from .. import foo_bar",
+            ],
+            id="underscore_package",
+        ),
     ],
 )
 def test_build_import_rewrites(proto: str, dep: str, expecteds: Iterable[str]) -> None:


### PR DESCRIPTION
- test: add failing test
- fix: add more underscores for imports
- style: remove unnecessar punctuation
- test: nest packages
