### PR TITLE
feat(protoc): forward protoc arguments to protoc generator

### DIFF
--- a/protoletariat/__main__.py
+++ b/protoletariat/__main__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import IO
+from typing import IO, Iterable
 
 import click
 
@@ -100,7 +100,10 @@ def main(
     )
 
 
-@main.command(help="Use protoc to generate the FileDescriptorSet blob")
+@main.command(
+    context_settings=dict(ignore_unknown_options=True),
+    help="Use protoc to generate the FileDescriptorSet blob",
+)
 @click.option(
     "--protoc-path",
     envvar="PROTOC_PATH",
@@ -124,28 +127,18 @@ def main(
     ),
     help="Protobuf file search path(s). Accepts multiple values.",
 )
-@click.argument(
-    "proto_files",
-    nargs=-1,
-    required=True,
-    type=click.Path(
-        file_okay=True,
-        dir_okay=False,
-        exists=True,
-        path_type=Path,
-    ),
-)
+@click.argument("protoc_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def protoc(
     ctx: click.Context,
     protoc_path: str,
     proto_paths: list[Path],
-    proto_files: list[Path],
+    protoc_args: Iterable[str],
 ) -> None:
     Protoc(
         protoc_path=os.fsdecode(protoc_path),
-        proto_files=[Path(os.fsdecode(proto_file)) for proto_file in proto_files],
         proto_paths=[Path(os.fsdecode(proto_path)) for proto_path in proto_paths],
+        protoc_args=list(protoc_args),
     ).fix_imports(**ctx.obj)
 
 

--- a/protoletariat/fdsetgen.py
+++ b/protoletariat/fdsetgen.py
@@ -143,25 +143,24 @@ class Protoc(FileDescriptorSetGenerator):
         self,
         *,
         protoc_path: str,
-        proto_files: Iterable[Path],
         proto_paths: Iterable[Path],
+        protoc_args: Iterable[str],
     ) -> None:
         self.protoc_path = protoc_path
-        self.proto_files = proto_files
         self.proto_paths = proto_paths
+        self.protoc_args = protoc_args
 
     def generate_file_descriptor_set_bytes(self) -> bytes:
         with tempfile.NamedTemporaryFile(delete=False) as f:
             filename = Path(f.name)
-            subprocess.check_output(
-                [
-                    *shlex.split(self.protoc_path),
-                    "--include_imports",
-                    f"--descriptor_set_out={filename}",
-                    *map("--proto_path={}".format, self.proto_paths),
-                    *map(str, self.proto_files),
-                ]
-            )
+            args = [
+                *shlex.split(self.protoc_path),
+                "--include_imports",
+                f"--descriptor_set_out={filename}",
+                *map("--proto_path={}".format, self.proto_paths),
+                *self.protoc_args,
+            ]
+            subprocess.check_output(args)
 
         try:
             return filename.read_bytes()


### PR DESCRIPTION
This PR adds support for forwarding unknown arguments to protoc, including `--descriptor_set_in`. Closes #478.